### PR TITLE
Enable mobile play with touch controls

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,4 +4,4 @@ A simple runner game inspired by the Chrome offline T-Rex, but featuring a princ
 
 ## Avvio
 
-Apri `index.html` in un browser moderno e premi la barra spaziatrice per saltare gli ostacoli.
+Apri `index.html` in un browser moderno e premi la barra spaziatrice o tocca lo schermo per saltare gli ostacoli.

--- a/game.js
+++ b/game.js
@@ -1,7 +1,8 @@
 const canvas = document.getElementById('game');
 const ctx = canvas.getContext('2d');
 
-const groundY = 150;
+canvas.height = 200;
+let groundY = canvas.height - 50;
 
 const unicorn = {
   x: 50,
@@ -12,22 +13,44 @@ const unicorn = {
   jumping: false
 };
 
+function resizeCanvas() {
+  canvas.width = window.innerWidth;
+  groundY = canvas.height - 50;
+  if (!unicorn.jumping) {
+    unicorn.y = groundY;
+  }
+}
+
+window.addEventListener('resize', resizeCanvas);
+resizeCanvas();
+
 let obstacles = [];
 let score = 0;
 let speed = 6;
 let gravity = 0.6;
 let gameOver = false;
 
+function handleInput() {
+  if (gameOver) {
+    reset();
+  } else if (!unicorn.jumping) {
+    unicorn.vy = -12;
+    unicorn.jumping = true;
+  }
+}
+
 document.addEventListener('keydown', (e) => {
   if (e.code === 'Space') {
-    if (gameOver) {
-      reset();
-    } else if (!unicorn.jumping) {
-      unicorn.vy = -12;
-      unicorn.jumping = true;
-    }
+    handleInput();
   }
 });
+
+document.addEventListener('touchstart', (e) => {
+  e.preventDefault();
+  handleInput();
+}, { passive: false });
+
+document.addEventListener('mousedown', handleInput);
 
 function reset() {
   obstacles = [];
@@ -99,12 +122,14 @@ function draw() {
 
   ctx.fillStyle = '#000';
   ctx.font = '16px sans-serif';
-  ctx.fillText(`Punteggio: ${score}`, 650, 20);
+  ctx.fillText(`Punteggio: ${score}`, canvas.width - 150, 20);
 
   if (gameOver) {
     ctx.fillStyle = '#000';
     ctx.font = '24px sans-serif';
-    ctx.fillText('Game Over - premi Spazio per ricominciare', 120, 100);
+    const msg = 'Game Over - tocca o premi Spazio per ricominciare';
+    const msgWidth = ctx.measureText(msg).width;
+    ctx.fillText(msg, (canvas.width - msgWidth) / 2, 100);
   }
 }
 

--- a/index.html
+++ b/index.html
@@ -2,16 +2,17 @@
 <html lang="it">
 <head>
   <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Principessa sull'Unicorno Runner</title>
   <style>
     body { text-align: center; font-family: sans-serif; }
-    canvas { background: #f0f0f0; display: block; margin: 0 auto; }
+    canvas { background: #f0f0f0; display: block; margin: 0 auto; width: 100%; }
   </style>
 </head>
 <body>
   <h1>Principessa sull'Unicorno Runner</h1>
-  <p>Premi la barra spaziatrice per saltare.</p>
-  <canvas id="game" width="800" height="200"></canvas>
+  <p>Premi la barra spaziatrice o tocca lo schermo per saltare.</p>
+  <canvas id="game" height="200"></canvas>
   <script src="game.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- add mobile-friendly viewport and touch instructions
- make canvas responsive and handle touch/mouse input for jumping
- update score and Game Over messages to display properly on any screen

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a9be9b2268832c82758cdf321e2c7a