### PR TITLE
Fix unicorn jump on mobile with pointer events

### DIFF
--- a/game.js
+++ b/game.js
@@ -45,12 +45,7 @@ document.addEventListener('keydown', (e) => {
   }
 });
 
-document.addEventListener('touchstart', (e) => {
-  e.preventDefault();
-  handleInput();
-}, { passive: false });
-
-document.addEventListener('mousedown', handleInput);
+window.addEventListener('pointerdown', handleInput);
 
 function reset() {
   obstacles = [];


### PR DESCRIPTION
## Summary
- handle taps and clicks through a single `pointerdown` event so the unicorn jumps on mobile

## Testing
- `node --check game.js && echo 'Syntax OK'`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a9c8dd39e0832cb77e9dc906e1d379