### PR TITLE
Add direct second-level link

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,14 @@ A simple runner game inspired by the Chrome offline T-Rex, but featuring a princ
 Apri `index.html` in un browser moderno e premi la barra spaziatrice o tocca lo schermo per saltare gli ostacoli.
 L'obiettivo è raggiungere 1000 punti e superare il Cavaliere Nero; il gioco è stato reso più semplice per essere adatto anche ai più piccoli.
 
+Per accedere direttamente al secondo livello (la sfida con il Cavaliere Nero) senza passare dal primo, apri:
+
+```
+index.html?level=2
+```
+
+Questo URL salta il primo livello e avvia subito il boss fight.
+
 ## Test
 
 Esegui i test unitari con:

--- a/game.js
+++ b/game.js
@@ -24,6 +24,13 @@ function resizeCanvas() {
 window.addEventListener('resize', resizeCanvas);
 resizeCanvas();
 
+// Allow starting directly at the boss level via URL parameter ?level=2
+const params = new URLSearchParams(window.location.search);
+if (params.get('level') === '2') {
+  score = 1000;
+  boss = { x: canvas.width, width: 40, height: 60 };
+}
+
 let obstacles = [];
 let score = 0;
 // Slower game speed and lower gravity make the game easier


### PR DESCRIPTION
## Summary
- Allow skipping straight to boss level using `?level=2` in the URL
- Document the direct link in the README

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a9d41a2c0c832c95fd039393fe1985