### PR TITLE
feat: add shield-based boss level

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,12 @@ index.html?level=2
 
 Questo URL salta il primo livello e avvia subito il boss fight.
 
+Nel secondo livello il Cavaliere Nero lancia dei muri contro l'unicorno.
+Premi di nuovo la barra spaziatrice o tocca lo schermo per attivare uno
+scudo: se un muro lo raggiunge mentre lo scudo è attivo il muro viene
+frantumato e l'unicorno avanza verso il nemico. Quando il cavaliere è
+abbastanza vicino fugge e la principessa vince.
+
 ## Test
 
 Esegui i test unitari con:


### PR DESCRIPTION
## Summary
- introduce shield-based boss encounter after 1000 points
- allow starting directly at the boss level via URL parameter
- document new second-level mechanics

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a9d60c7e8c832cbedd4ff8f101a083