### PR TITLE
Add coin rewards for broken walls

### DIFF
--- a/src/game.js
+++ b/src/game.js
@@ -15,6 +15,7 @@ export class Game {
     this.speed = 3;
     this.gravity = 0.4;
     this.score = 0;
+    this.coins = 0;
     this.gameOver = false;
     this.win = false;
     this.gamePaused = true;
@@ -80,6 +81,7 @@ export class Game {
 
   reset() {
     this.score = 0;
+    this.coins = 0;
     this.gameOver = false;
     this.win = false;
     this.player = new Player(50, this.groundY);

--- a/src/levels/level2.js
+++ b/src/levels/level2.js
@@ -9,6 +9,7 @@ export class Level2 {
     this.wallInterval = 90;
     this.boss = { x: game.canvas.width - 100, y: game.groundY, width: 40, height: 50 };
     this.bossFlee = false;
+    this.coins = [];
   }
 
   update() {
@@ -26,6 +27,13 @@ export class Level2 {
       if (isColliding(this.game.player, w)) {
         if (this.game.player.shieldActive) {
           this.game.player.x += 20;
+          this.coins.push({
+            x: w.x + w.width / 2,
+            y: w.y - w.height / 2,
+            vy: -2,
+            life: 30
+          });
+          this.game.coins++;
           return false;
         }
         this.game.gameOver = true;
@@ -33,6 +41,14 @@ export class Level2 {
       }
       return true;
     });
+
+    this.coins.forEach(c => {
+      c.x -= speed;
+      c.y += c.vy;
+      c.vy += 0.1;
+      c.life--;
+    });
+    this.coins = this.coins.filter(c => c.life > 0 && c.x > -10);
 
     if (this.game.player.x + this.game.player.width >= this.boss.x - 20) {
       this.bossFlee = true;

--- a/src/renderer.js
+++ b/src/renderer.js
@@ -56,9 +56,29 @@ export class Renderer {
       ctx.fillRect(b.x, b.y - b.height, b.width, b.height);
     }
 
+    if (game.level.coins) {
+      game.level.coins.forEach(c => {
+        ctx.fillStyle = 'gold';
+        ctx.beginPath();
+        ctx.arc(c.x, c.y, 5, 0, Math.PI * 2);
+        ctx.fill();
+      });
+    }
+
     ctx.fillStyle = '#000';
     ctx.font = '16px sans-serif';
-    ctx.fillText(`Punteggio: ${game.score}`, game.canvas.width - 150, 20);
+    ctx.textAlign = 'left';
+    ctx.fillText(`Punteggio: ${game.score}`, 10, 20);
+
+    const coinX = game.canvas.width - 20;
+    ctx.fillStyle = 'gold';
+    ctx.beginPath();
+    ctx.arc(coinX, 15, 8, 0, Math.PI * 2);
+    ctx.fill();
+    ctx.fillStyle = '#000';
+    ctx.textAlign = 'right';
+    ctx.fillText(`x ${game.coins}`, coinX - 10, 20);
+    ctx.textAlign = 'left';
 
     if (game.gameOver) {
       ctx.fillStyle = '#000';


### PR DESCRIPTION
## Summary
- Award coins when the princess destroys walls in level 2
- Animate coins and display a counter in the top-right corner
- Reset and track total coins collected

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a9f0638144832ca89bd5715e6ac40d