### PR TITLE
Fix level transition at 1000 points

### DIFF
--- a/game.test.js
+++ b/game.test.js
@@ -1,0 +1,67 @@
+import test from 'node:test';
+import assert from 'node:assert';
+import { Game } from './src/game.js';
+import { Level2 } from './src/levels/level2.js';
+
+function createStubGame() {
+  const noop = () => {};
+  const ctx = {
+    clearRect: noop,
+    fillRect: noop,
+    beginPath: noop,
+    moveTo: noop,
+    lineTo: noop,
+    fill: noop,
+    arc: noop,
+    stroke: noop,
+    fillText: noop,
+    measureText: () => ({ width: 0 }),
+  };
+  const canvas = { width: 800, height: 200, getContext: () => ctx };
+  const overlay = { classList: { add: noop, remove: noop } };
+  const overlayContent = {};
+  const overlayButton = {};
+
+  global.document = {
+    getElementById: (id) => {
+      switch (id) {
+        case 'game':
+          return canvas;
+        case 'overlay':
+          return overlay;
+        case 'overlay-content':
+          return overlayContent;
+        case 'overlay-button':
+          return overlayButton;
+        default:
+          return null;
+      }
+    },
+    addEventListener: noop,
+    removeEventListener: noop,
+  };
+  global.window = {
+    innerWidth: 800,
+    location: { search: '' },
+    addEventListener: noop,
+    removeEventListener: noop,
+    requestAnimationFrame: noop,
+  };
+
+  const game = new Game(canvas);
+  game.gamePaused = false;
+  game.showOverlay = noop;
+  game.level.update = noop;
+  return game;
+}
+
+test('advances to level 2 after reaching 1000 points', () => {
+  const game = createStubGame();
+  for (let i = 0; i < 999; i++) {
+    game.update();
+  }
+  assert.strictEqual(game.levelNumber, 1);
+  game.update();
+  assert.strictEqual(game.levelNumber, 2);
+  assert.ok(game.level instanceof Level2);
+});

--- a/src/game.js
+++ b/src/game.js
@@ -97,6 +97,20 @@ export class Game {
     this.player.update(this.gravity, this.groundY);
     this.level.update();
     if (!this.gameOver) this.score++;
+
+    if (this.levelNumber === 1 && this.score >= 1000) {
+      this.levelNumber = 2;
+      this.player = new Player(50, this.groundY);
+      this.level = new Level2(this);
+      this.gamePaused = true;
+      this.showOverlay(this.storyText[1], () => {
+        this.showOverlay(this.instructionsText[2], () => {
+          this.gamePaused = false;
+          this.loop();
+        });
+      });
+    }
+
     if (this.gameOver) this.gamePaused = true;
   }
 


### PR DESCRIPTION
## Summary
- trigger second level and narrative when score hits 1000
- cover level progression with a unit test

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a9fbcef218832c8ad80aefbcb1124f