### PR TITLE
Fix game over restart handling

### DIFF
--- a/game.test.js
+++ b/game.test.js
@@ -65,3 +65,15 @@ test('advances to level 2 after reaching 1000 points', () => {
   assert.strictEqual(game.levelNumber, 2);
   assert.ok(game.level instanceof Level2);
 });
+
+test('resets when action is triggered after game over', () => {
+  const game = createStubGame();
+  let resetCalled = false;
+  game.reset = () => {
+    resetCalled = true;
+  };
+  game.gameOver = true;
+  game.gamePaused = true;
+  game.handleInput();
+  assert.ok(resetCalled);
+});

--- a/src/game.js
+++ b/src/game.js
@@ -69,10 +69,14 @@ export class Game {
   }
 
   handleInput() {
-    if (this.gamePaused) return;
     if (this.gameOver) {
       this.reset();
-    } else if (this.levelNumber === 1) {
+      return;
+    }
+
+    if (this.gamePaused) return;
+
+    if (this.levelNumber === 1) {
       this.player.jump();
     } else {
       this.player.activateShield();


### PR DESCRIPTION
## Summary
- ensure input resets game even when paused after game over
- add test for reset when pressing action during game over

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a9fd00e388832cb32aaa46b9c42a74