### PR TITLE
Implement 80% flee rule for Level 2 boss

### DIFF
--- a/level2.test.js
+++ b/level2.test.js
@@ -1,0 +1,78 @@
+import test from 'node:test';
+import assert from 'node:assert';
+import { Game } from './src/game.js';
+import { Level2 } from './src/levels/level2.js';
+
+function createStubGame() {
+  const noop = () => {};
+  const ctx = {
+    clearRect: noop,
+    fillRect: noop,
+    beginPath: noop,
+    moveTo: noop,
+    lineTo: noop,
+    fill: noop,
+    arc: noop,
+    stroke: noop,
+    fillText: noop,
+    measureText: () => ({ width: 0 }),
+  };
+  const canvas = { width: 800, height: 200, getContext: () => ctx };
+  const overlay = { classList: { add: noop, remove: noop } };
+  const overlayContent = {};
+  const overlayButton = {};
+
+  global.document = {
+    getElementById: (id) => {
+      switch (id) {
+        case 'game':
+          return canvas;
+        case 'overlay':
+          return overlay;
+        case 'overlay-content':
+          return overlayContent;
+        case 'overlay-button':
+          return overlayButton;
+        default:
+          return null;
+      }
+    },
+    addEventListener: noop,
+    removeEventListener: noop,
+  };
+  global.window = {
+    innerWidth: 800,
+    location: { search: '' },
+    addEventListener: noop,
+    removeEventListener: noop,
+    requestAnimationFrame: noop,
+  };
+
+  const game = new Game(canvas);
+  game.showOverlay = noop;
+  game.gamePaused = false;
+  game.level.update = noop;
+  return game;
+}
+
+test('boss flees after player covers 80% of distance', () => {
+  const game = createStubGame();
+  const level = new Level2(game);
+  const initialDistance = level.boss.x - (game.player.x + game.player.width);
+  const threshold = initialDistance * 0.2;
+
+  game.player.x = level.boss.x - threshold - game.player.width;
+  level.update();
+  assert.ok(level.bossFlee);
+});
+
+test('boss does not flee before player covers 80% of distance', () => {
+  const game = createStubGame();
+  const level = new Level2(game);
+  const initialDistance = level.boss.x - (game.player.x + game.player.width);
+  const almostThreshold = initialDistance * 0.21;
+
+  game.player.x = level.boss.x - almostThreshold - game.player.width;
+  level.update();
+  assert.ok(!level.bossFlee);
+});

--- a/src/levels/level2.js
+++ b/src/levels/level2.js
@@ -10,6 +10,8 @@ export class Level2 {
     this.boss = { x: game.canvas.width - 100, y: game.groundY, width: 40, height: 50 };
     this.bossFlee = false;
     this.coins = [];
+    this.initialDistance =
+      this.boss.x - (this.game.player.x + this.game.player.width);
   }
 
   update() {
@@ -50,7 +52,9 @@ export class Level2 {
     });
     this.coins = this.coins.filter(c => c.life > 0 && c.x > -10);
 
-    if (this.game.player.x + this.game.player.width >= this.boss.x - 20) {
+    const currentDistance =
+      this.boss.x - (this.game.player.x + this.game.player.width);
+    if (currentDistance <= this.initialDistance * 0.2) {
       this.bossFlee = true;
     }
     if (this.bossFlee) {


### PR DESCRIPTION
## Summary
- Track initial distance to black knight boss and trigger flee at 80% proximity
- Add Level 2 tests confirming boss flees only after player covers 80% of gap

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68aa05c8d0ac832ca03e1a089fe98878