### PR TITLE
Aggiungi menu iniziale con crediti

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,10 @@ scudo: se un muro lo raggiunge mentre lo scudo è attivo il muro viene
 frantumato e l'unicorno avanza verso il nemico. Quando il cavaliere è
 abbastanza vicino fugge e la principessa vince.
 
+## Credits
+
+Gioco realizzato quasi interamente con l'aiuto di ChatGPT.
+
 ## Test
 
 Esegui i test unitari con:

--- a/index.html
+++ b/index.html
@@ -8,9 +8,12 @@
 </head>
 <body>
   <h1>Principessa sull'Unicorno Runner</h1>
-  <p>Premi la barra spaziatrice o tocca lo schermo per saltare.</p>
-  <p>Raggiungi 1000 punti e supera il Cavaliere Nero per vincere!</p>
-  <canvas id="game" height="200"></canvas>
+  <div id="menu">
+    <button id="play-button">Gioca</button>
+    <button id="instructions-button">Istruzioni</button>
+    <button id="credits-button">Credits</button>
+  </div>
+  <canvas id="game" class="hidden" height="200"></canvas>
   <div id="overlay" class="overlay hidden">
     <div id="overlay-content"></div>
     <button id="overlay-button">Continua</button>

--- a/main.js
+++ b/main.js
@@ -2,6 +2,36 @@ import { Game } from './src/game.js';
 
 window.addEventListener('DOMContentLoaded', () => {
   const canvas = document.getElementById('game');
-  canvas.height = 200;
-  const game = new Game(canvas);
+  const menu = document.getElementById('menu');
+  const playButton = document.getElementById('play-button');
+  const instructionsButton = document.getElementById('instructions-button');
+  const creditsButton = document.getElementById('credits-button');
+  const overlay = document.getElementById('overlay');
+  const overlayContent = document.getElementById('overlay-content');
+  const overlayButton = document.getElementById('overlay-button');
+
+  playButton.addEventListener('click', () => {
+    menu.classList.add('hidden');
+    canvas.classList.remove('hidden');
+    canvas.height = 200;
+    new Game(canvas);
+  });
+
+  const showSimpleOverlay = (text) => {
+    overlayContent.textContent = text;
+    overlayButton.textContent = 'Indietro';
+    overlay.classList.remove('hidden');
+    overlayButton.onclick = () => {
+      overlay.classList.add('hidden');
+      overlayButton.onclick = null;
+    };
+  };
+
+  instructionsButton.addEventListener('click', () => {
+    showSimpleOverlay('Premi la barra spaziatrice o tocca lo schermo per saltare. Raggiungi 1000 punti e supera il Cavaliere Nero per vincere!');
+  });
+
+  creditsButton.addEventListener('click', () => {
+    showSimpleOverlay("Gioco realizzato quasi interamente con l'aiuto di ChatGPT.");
+  });
 });

--- a/style.css
+++ b/style.css
@@ -1,5 +1,13 @@
 body { text-align: center; font-family: sans-serif; }
 canvas { background: #f0f0f0; display: block; margin: 0 auto; width: 100%; }
+#menu {
+  margin-top: 20px;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  align-items: center;
+}
+#menu button { padding: 10px 20px; }
 .overlay {
   position: fixed;
   top: 0;


### PR DESCRIPTION
## Summary
- Introduce un menu iniziale con opzioni Gioca, Istruzioni e Credits.
- Mostra i crediti con menzione a ChatGPT e aggiorna il README.
- Stili dedicati per il menu e gestione overlay tramite JavaScript.

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68aa0860b3e8832cac4af68c71bd685d