### PR TITLE
Fix Level2 boss initial distance

### DIFF
--- a/level2.test.js
+++ b/level2.test.js
@@ -3,7 +3,7 @@ import assert from 'node:assert';
 import { Game } from './src/game.js';
 import { Level2 } from './src/levels/level2.js';
 
-function createStubGame() {
+function createStubGame({ canvasWidth = 800, innerWidth = 800, search = '' } = {}) {
   const noop = () => {};
   const ctx = {
     clearRect: noop,
@@ -17,10 +17,10 @@ function createStubGame() {
     fillText: noop,
     measureText: () => ({ width: 0 }),
   };
-  const canvas = { width: 800, height: 200, getContext: () => ctx };
+  const canvas = { width: canvasWidth, height: 200, getContext: () => ctx };
   const overlay = { classList: { add: noop, remove: noop } };
-  const overlayContent = {};
-  const overlayButton = {};
+  const overlayContent = { textContent: '' };
+  const overlayButton = { onclick: null };
 
   global.document = {
     getElementById: (id) => {
@@ -41,8 +41,8 @@ function createStubGame() {
     removeEventListener: noop,
   };
   global.window = {
-    innerWidth: 800,
-    location: { search: '' },
+    innerWidth,
+    location: { search },
     addEventListener: noop,
     removeEventListener: noop,
     requestAnimationFrame: noop,
@@ -75,4 +75,10 @@ test('boss does not flee before player covers 80% of distance', () => {
   game.player.x = level.boss.x - almostThreshold - game.player.width;
   level.update();
   assert.ok(!level.bossFlee);
+});
+
+test('boss initial position uses resized canvas width', () => {
+  const game = createStubGame({ canvasWidth: 300, innerWidth: 800, search: '?level=2' });
+  assert.strictEqual(game.canvas.width, 800);
+  assert.strictEqual(game.level.boss.x, 700);
 });

--- a/src/game.js
+++ b/src/game.js
@@ -23,16 +23,15 @@ export class Game {
     this.params = new URLSearchParams(window.location.search);
     this.levelNumber = this.params.get('level') === '2' ? 2 : 1;
 
-    this.groundY = canvas.height - 50;
+    window.addEventListener('resize', () => this.resizeCanvas());
+    this.resizeCanvas();
+
     this.player = new Player(50, this.groundY);
     this.level = this.levelNumber === 1 ? new Level1(this) : new Level2(this);
     this.renderer = new Renderer(this);
 
     this.input = new InputHandler(() => this.handleInput());
     this.input.attach();
-
-    window.addEventListener('resize', () => this.resizeCanvas());
-    this.resizeCanvas();
 
     this.showOverlay(this.instructionsText[this.levelNumber], () => {
       this.gamePaused = false;
@@ -63,7 +62,7 @@ export class Game {
   resizeCanvas() {
     this.canvas.width = window.innerWidth;
     this.groundY = this.canvas.height - 50;
-    if (!this.player.jumping) {
+    if (this.player && !this.player.jumping) {
       this.player.y = this.groundY;
     }
   }


### PR DESCRIPTION
## Summary
- Initialize canvas size before creating player and level to prevent boss spawning too close
- Ensure resize logic handles missing player
- Add regression test for Level2 boss starting distance

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68aa09ede518832c8dc56b16e0ba073d