### PR TITLE
Make boss flee at 70% distance in level 2

### DIFF
--- a/level2.test.js
+++ b/level2.test.js
@@ -55,22 +55,22 @@ function createStubGame({ canvasWidth = 800, innerWidth = 800, search = '' } = {
   return game;
 }
 
-test('boss flees after player covers 80% of distance', () => {
+test('boss flees after player covers 70% of distance', () => {
   const game = createStubGame();
   const level = new Level2(game);
   const initialDistance = level.boss.x - (game.player.x + game.player.width);
-  const threshold = initialDistance * 0.2;
+  const threshold = initialDistance * 0.3;
 
   game.player.x = level.boss.x - threshold - game.player.width;
   level.update();
   assert.ok(level.bossFlee);
 });
 
-test('boss does not flee before player covers 80% of distance', () => {
+test('boss does not flee before player covers 70% of distance', () => {
   const game = createStubGame();
   const level = new Level2(game);
   const initialDistance = level.boss.x - (game.player.x + game.player.width);
-  const almostThreshold = initialDistance * 0.21;
+  const almostThreshold = initialDistance * 0.31;
 
   game.player.x = level.boss.x - almostThreshold - game.player.width;
   level.update();

--- a/src/levels/level2.js
+++ b/src/levels/level2.js
@@ -54,7 +54,7 @@ export class Level2 {
 
     const currentDistance =
       this.boss.x - (this.game.player.x + this.game.player.width);
-    if (currentDistance <= this.initialDistance * 0.2) {
+    if (currentDistance <= this.initialDistance * 0.3) {
       this.bossFlee = true;
     }
     if (this.bossFlee) {


### PR DESCRIPTION
## Summary
- Make Level 2 boss flee when only 30% of initial distance remains
- Adjust Level 2 tests to cover 70% flee threshold

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68aa0b5056c8832c869e6c7c23f98e2a