### PR TITLE
Prevent shield spamming in level two

### DIFF
--- a/level2.test.js
+++ b/level2.test.js
@@ -82,3 +82,24 @@ test('boss initial position uses resized canvas width', () => {
   assert.strictEqual(game.canvas.width, 800);
   assert.strictEqual(game.level.boss.x, 700);
 });
+
+test('shield deactivates even when input is spammed', () => {
+  const game = createStubGame({ search: '?level=2' });
+  const player = game.player;
+  for (let i = 0; i < 30; i++) {
+    game.handleInput();
+    player.update(0, game.groundY);
+  }
+  assert.strictEqual(player.shieldActive, false);
+});
+
+test('shield can be reactivated after cooldown', () => {
+  const game = createStubGame({ search: '?level=2' });
+  const player = game.player;
+  game.handleInput();
+  for (let i = 0; i < 60; i++) {
+    player.update(0, game.groundY);
+  }
+  game.handleInput();
+  assert.strictEqual(player.shieldActive, true);
+});

--- a/src/player.js
+++ b/src/player.js
@@ -8,6 +8,7 @@ export class Player {
     this.jumping = false;
     this.shieldActive = false;
     this.shieldTimer = 0;
+    this.shieldCooldown = 0;
   }
 
   update(gravity, groundY) {
@@ -22,6 +23,9 @@ export class Player {
       this.shieldTimer--;
       if (this.shieldTimer === 0) this.shieldActive = false;
     }
+    if (this.shieldCooldown > 0) {
+      this.shieldCooldown--;
+    }
   }
 
   jump() {
@@ -31,8 +35,11 @@ export class Player {
     }
   }
 
-  activateShield(duration = 15) {
-    this.shieldActive = true;
-    this.shieldTimer = duration;
+  activateShield(duration = 15, cooldown = 60) {
+    if (!this.shieldActive && this.shieldCooldown === 0) {
+      this.shieldActive = true;
+      this.shieldTimer = duration;
+      this.shieldCooldown = cooldown;
+    }
   }
 }


### PR DESCRIPTION
## Summary
- add cooldown to player shield to prevent constant activation
- test shield deactivation when input is spammed and reactivation after cooldown

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68aa0d713dd8832c98c427bdb05705d0