### PR TITLE
Track coins for level 1 and retain totals across levels

### DIFF
--- a/coins.test.js
+++ b/coins.test.js
@@ -1,0 +1,74 @@
+import test from 'node:test';
+import assert from 'node:assert';
+import { Game } from './src/game.js';
+import { Obstacle } from './src/obstacle.js';
+import { Level2 } from './src/levels/level2.js';
+
+function createStubGame() {
+  const noop = () => {};
+  const ctx = {
+    clearRect: noop,
+    fillRect: noop,
+    beginPath: noop,
+    moveTo: noop,
+    lineTo: noop,
+    fill: noop,
+    arc: noop,
+    stroke: noop,
+    fillText: noop,
+    measureText: () => ({ width: 0 }),
+  };
+  const canvas = { width: 800, height: 200, getContext: () => ctx };
+  const overlay = { classList: { add: noop, remove: noop } };
+  const overlayContent = {};
+  const overlayButton = {};
+
+  global.document = {
+    getElementById: (id) => {
+      switch (id) {
+        case 'game':
+          return canvas;
+        case 'overlay':
+          return overlay;
+        case 'overlay-content':
+          return overlayContent;
+        case 'overlay-button':
+          return overlayButton;
+        default:
+          return null;
+      }
+    },
+    addEventListener: noop,
+    removeEventListener: noop,
+  };
+
+  global.window = {
+    innerWidth: 800,
+    location: { search: '' },
+    addEventListener: noop,
+    removeEventListener: noop,
+    requestAnimationFrame: noop,
+  };
+
+  const game = new Game(canvas);
+  game.showOverlay = noop;
+  game.gamePaused = false;
+  return game;
+}
+
+test('awards coin for passed obstacle and preserves coins in level 2', () => {
+  const game = createStubGame();
+  const obstacle = new Obstacle(game.player.x - 30, game.groundY, 20, 40);
+  obstacle.coinAwarded = false;
+  game.level.obstacles.push(obstacle);
+
+  game.update();
+  assert.strictEqual(game.coins, 1);
+
+  game.score = 999;
+  game.update();
+  assert.strictEqual(game.levelNumber, 2);
+  assert.ok(game.level instanceof Level2);
+  assert.strictEqual(game.coins, 1);
+});
+

--- a/src/levels/level1.js
+++ b/src/levels/level1.js
@@ -16,13 +16,24 @@ export class Level1 {
   update() {
     this.timer++;
     if (this.timer > this.interval) {
-      this.obstacles.push(
-        new Obstacle(this.game.canvas.width, this.game.groundY, 20, 40)
+      const obstacle = new Obstacle(
+        this.game.canvas.width,
+        this.game.groundY,
+        20,
+        40
       );
+      obstacle.coinAwarded = false;
+      this.obstacles.push(obstacle);
       this.timer = 0;
       this.interval = Level1.getInterval();
     }
-    this.obstacles.forEach(o => o.update(this.game.speed));
+    this.obstacles.forEach(o => {
+      o.update(this.game.speed);
+      if (!o.coinAwarded && o.x + o.width < this.game.player.x) {
+        this.game.coins++;
+        o.coinAwarded = true;
+      }
+    });
     this.obstacles = this.obstacles.filter(o => o.x + o.width > 0);
 
     if (this.obstacles.some(o => isColliding(this.game.player, o))) {


### PR DESCRIPTION
## Summary
- Reward coins in level 1 for each obstacle safely passed
- Keep coins when transitioning to level 2
- Add regression test for coin accumulation persistence

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68aa1052601c832cae31ad7f8fda1a6e