### PR TITLE
Use delta time for consistent gameplay

### DIFF
--- a/coins.test.js
+++ b/coins.test.js
@@ -62,11 +62,11 @@ test('awards coin for passed obstacle and preserves coins in level 2', () => {
   obstacle.coinAwarded = false;
   game.level.obstacles.push(obstacle);
 
-  game.update();
+  game.update(1);
   assert.strictEqual(game.coins, 1);
 
   game.score = 999;
-  game.update();
+  game.update(1);
   assert.strictEqual(game.levelNumber, 2);
   assert.ok(game.level instanceof Level2);
   assert.strictEqual(game.coins, 1);

--- a/game.test.js
+++ b/game.test.js
@@ -58,10 +58,10 @@ function createStubGame() {
 test('advances to level 2 after reaching 1000 points', () => {
   const game = createStubGame();
   for (let i = 0; i < 999; i++) {
-    game.update();
+    game.update(1);
   }
   assert.strictEqual(game.levelNumber, 1);
-  game.update();
+  game.update(1);
   assert.strictEqual(game.levelNumber, 2);
   assert.ok(game.level instanceof Level2);
 });

--- a/level2.test.js
+++ b/level2.test.js
@@ -62,7 +62,7 @@ test('boss flees after player covers 70% of distance', () => {
   const threshold = initialDistance * 0.3;
 
   game.player.x = level.boss.x - threshold - game.player.width;
-  level.update();
+  level.update(1);
   assert.ok(level.bossFlee);
 });
 
@@ -73,7 +73,7 @@ test('boss does not flee before player covers 70% of distance', () => {
   const almostThreshold = initialDistance * 0.31;
 
   game.player.x = level.boss.x - almostThreshold - game.player.width;
-  level.update();
+  level.update(1);
   assert.ok(!level.bossFlee);
 });
 
@@ -88,7 +88,7 @@ test('shield deactivates even when input is spammed', () => {
   const player = game.player;
   for (let i = 0; i < 30; i++) {
     game.handleInput();
-    player.update(0, game.groundY);
+    player.update(0, game.groundY, 1);
   }
   assert.strictEqual(player.shieldActive, false);
 });
@@ -98,7 +98,7 @@ test('shield can be reactivated after cooldown', () => {
   const player = game.player;
   game.handleInput();
   for (let i = 0; i < 60; i++) {
-    player.update(0, game.groundY);
+    player.update(0, game.groundY, 1);
   }
   game.handleInput();
   assert.strictEqual(player.shieldActive, true);

--- a/src/levels/level1.js
+++ b/src/levels/level1.js
@@ -13,8 +13,8 @@ export class Level1 {
     return 80 + Math.random() * 70;
   }
 
-  update() {
-    this.timer++;
+  update(delta) {
+    this.timer += delta;
     if (this.timer > this.interval) {
       const obstacle = new Obstacle(
         this.game.canvas.width,
@@ -28,7 +28,7 @@ export class Level1 {
       this.interval = Level1.getInterval();
     }
     this.obstacles.forEach(o => {
-      o.update(this.game.speed);
+      o.update(this.game.speed * delta);
       if (!o.coinAwarded && o.x + o.width < this.game.player.x) {
         this.game.coins++;
         o.coinAwarded = true;

--- a/src/levels/level2.js
+++ b/src/levels/level2.js
@@ -14,9 +14,9 @@ export class Level2 {
       this.boss.x - (this.game.player.x + this.game.player.width);
   }
 
-  update() {
-    const speed = this.game.speed + 2;
-    this.wallTimer++;
+  update(delta) {
+    const speed = (this.game.speed + 2) * delta;
+    this.wallTimer += delta;
     if (this.wallTimer > this.wallInterval && !this.bossFlee) {
       this.walls.push(new Obstacle(this.boss.x, this.game.groundY, 30, 50));
       this.wallTimer = 0;
@@ -46,9 +46,9 @@ export class Level2 {
 
     this.coins.forEach(c => {
       c.x -= speed;
-      c.y += c.vy;
-      c.vy += 0.1;
-      c.life--;
+      c.y += c.vy * delta;
+      c.vy += 0.1 * delta;
+      c.life -= delta;
     });
     this.coins = this.coins.filter(c => c.life > 0 && c.x > -10);
 

--- a/src/player.js
+++ b/src/player.js
@@ -11,20 +11,21 @@ export class Player {
     this.shieldCooldown = 0;
   }
 
-  update(gravity, groundY) {
-    this.vy += gravity;
-    this.y += this.vy;
+  update(gravity, groundY, delta) {
+    this.vy += gravity * delta;
+    this.y += this.vy * delta;
     if (this.y >= groundY) {
       this.y = groundY;
       this.vy = 0;
       this.jumping = false;
     }
     if (this.shieldTimer > 0) {
-      this.shieldTimer--;
-      if (this.shieldTimer === 0) this.shieldActive = false;
+      this.shieldTimer -= delta;
+      if (this.shieldTimer <= 0) this.shieldActive = false;
     }
     if (this.shieldCooldown > 0) {
-      this.shieldCooldown--;
+      this.shieldCooldown -= delta;
+      if (this.shieldCooldown < 0) this.shieldCooldown = 0;
     }
   }
 

--- a/src/renderer.js
+++ b/src/renderer.js
@@ -68,7 +68,7 @@ export class Renderer {
     ctx.fillStyle = '#000';
     ctx.font = '16px sans-serif';
     ctx.textAlign = 'left';
-    ctx.fillText(`Punteggio: ${game.score}`, 10, 20);
+    ctx.fillText(`Punteggio: ${Math.floor(game.score)}`, 10, 20);
 
     const coinX = game.canvas.width - 20;
     ctx.fillStyle = 'gold';


### PR DESCRIPTION
## Summary
- Add delta-time based loop for frame-rate independent updates
- Scale physics, timers, and score using elapsed time
- Show rounded score in the HUD

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68aa14b348ec832ca675d50b98004627