### PR TITLE
Add delta time for consistent physics

### DIFF
--- a/coins.test.js
+++ b/coins.test.js
@@ -4,6 +4,8 @@ import { Game } from './src/game.js';
 import { Obstacle } from './src/obstacle.js';
 import { Level2 } from './src/levels/level2.js';
 
+const FRAME = 1 / 60;
+
 function createStubGame() {
   const noop = () => {};
   const ctx = {
@@ -62,11 +64,11 @@ test('awards coin for passed obstacle and preserves coins in level 2', () => {
   obstacle.coinAwarded = false;
   game.level.obstacles.push(obstacle);
 
-  game.update(1);
+  game.update(FRAME);
   assert.strictEqual(game.coins, 1);
 
   game.score = 999;
-  game.update(1);
+  game.update(FRAME);
   assert.strictEqual(game.levelNumber, 2);
   assert.ok(game.level instanceof Level2);
   assert.strictEqual(game.coins, 1);

--- a/game.test.js
+++ b/game.test.js
@@ -3,6 +3,8 @@ import assert from 'node:assert';
 import { Game } from './src/game.js';
 import { Level2 } from './src/levels/level2.js';
 
+const FRAME = 1 / 60;
+
 function createStubGame() {
   const noop = () => {};
   const ctx = {
@@ -58,10 +60,10 @@ function createStubGame() {
 test('advances to level 2 after reaching 1000 points', () => {
   const game = createStubGame();
   for (let i = 0; i < 999; i++) {
-    game.update(1);
+    game.update(FRAME);
   }
   assert.strictEqual(game.levelNumber, 1);
-  game.update(1);
+  game.update(FRAME);
   assert.strictEqual(game.levelNumber, 2);
   assert.ok(game.level instanceof Level2);
 });

--- a/level2.test.js
+++ b/level2.test.js
@@ -3,6 +3,8 @@ import assert from 'node:assert';
 import { Game } from './src/game.js';
 import { Level2 } from './src/levels/level2.js';
 
+const FRAME = 1 / 60;
+
 function createStubGame({ canvasWidth = 800, innerWidth = 800, search = '' } = {}) {
   const noop = () => {};
   const ctx = {
@@ -62,7 +64,7 @@ test('boss flees after player covers 70% of distance', () => {
   const threshold = initialDistance * 0.3;
 
   game.player.x = level.boss.x - threshold - game.player.width;
-  level.update(1);
+  level.update(FRAME);
   assert.ok(level.bossFlee);
 });
 
@@ -73,7 +75,7 @@ test('boss does not flee before player covers 70% of distance', () => {
   const almostThreshold = initialDistance * 0.31;
 
   game.player.x = level.boss.x - almostThreshold - game.player.width;
-  level.update(1);
+  level.update(FRAME);
   assert.ok(!level.bossFlee);
 });
 
@@ -88,7 +90,7 @@ test('shield deactivates even when input is spammed', () => {
   const player = game.player;
   for (let i = 0; i < 30; i++) {
     game.handleInput();
-    player.update(0, game.groundY, 1);
+    player.update(0, game.groundY, FRAME);
   }
   assert.strictEqual(player.shieldActive, false);
 });
@@ -98,7 +100,7 @@ test('shield can be reactivated after cooldown', () => {
   const player = game.player;
   game.handleInput();
   for (let i = 0; i < 60; i++) {
-    player.update(0, game.groundY, 1);
+    player.update(0, game.groundY, FRAME);
   }
   game.handleInput();
   assert.strictEqual(player.shieldActive, true);

--- a/src/game.js
+++ b/src/game.js
@@ -12,8 +12,8 @@ export class Game {
     this.overlayContent = document.getElementById('overlay-content');
     this.overlayButton = document.getElementById('overlay-button');
 
-    this.speed = 3;
-    this.gravity = 0.4;
+    this.speed = 180; // pixels per second
+    this.gravity = 24; // acceleration per second^2
     this.score = 0;
     this.coins = 0;
     this.gameOver = false;
@@ -104,7 +104,7 @@ export class Game {
   update(delta) {
     this.player.update(this.gravity, this.groundY, delta);
     this.level.update(delta);
-    if (!this.gameOver) this.score += delta;
+    if (!this.gameOver) this.score += delta * 60;
 
     if (this.levelNumber === 1 && this.score >= 1000) {
       this.levelNumber = 2;
@@ -129,7 +129,7 @@ export class Game {
 
   loop(timestamp) {
     if (!this.lastTime) this.lastTime = timestamp;
-    const delta = (timestamp - this.lastTime) / (1000 / 60);
+    const delta = (timestamp - this.lastTime) / 1000;
     this.lastTime = timestamp;
     this.update(delta);
     this.draw();

--- a/src/levels/level1.js
+++ b/src/levels/level1.js
@@ -10,7 +10,7 @@ export class Level1 {
   }
 
   static getInterval() {
-    return 80 + Math.random() * 70;
+    return (80 + Math.random() * 70) / 60; // seconds
   }
 
   update(delta) {

--- a/src/levels/level2.js
+++ b/src/levels/level2.js
@@ -6,7 +6,7 @@ export class Level2 {
     this.game = game;
     this.walls = [];
     this.wallTimer = 0;
-    this.wallInterval = 90;
+    this.wallInterval = 90 / 60; // seconds
     this.boss = { x: game.canvas.width - 100, y: game.groundY, width: 40, height: 50 };
     this.bossFlee = false;
     this.coins = [];
@@ -15,15 +15,16 @@ export class Level2 {
   }
 
   update(delta) {
-    const speed = (this.game.speed + 2) * delta;
+    const speed = this.game.speed + 120; // px per second
+    const move = speed * delta;
     this.wallTimer += delta;
     if (this.wallTimer > this.wallInterval && !this.bossFlee) {
       this.walls.push(new Obstacle(this.boss.x, this.game.groundY, 30, 50));
       this.wallTimer = 0;
-      this.wallInterval = 60 + Math.random() * 60;
+      this.wallInterval = (60 + Math.random() * 60) / 60;
     }
 
-    this.walls.forEach(w => w.update(speed));
+    this.walls.forEach(w => w.update(move));
     this.walls = this.walls.filter(w => {
       if (w.x + w.width < 0) return false;
       if (isColliding(this.game.player, w)) {
@@ -32,8 +33,8 @@ export class Level2 {
           this.coins.push({
             x: w.x + w.width / 2,
             y: w.y - w.height / 2,
-            vy: -2,
-            life: 30
+            vy: -120,
+            life: 0.5
           });
           this.game.coins++;
           return false;
@@ -45,9 +46,9 @@ export class Level2 {
     });
 
     this.coins.forEach(c => {
-      c.x -= speed;
+      c.x -= move;
       c.y += c.vy * delta;
-      c.vy += 0.1 * delta;
+      c.vy += 6 * delta;
       c.life -= delta;
     });
     this.coins = this.coins.filter(c => c.life > 0 && c.x > -10);
@@ -58,7 +59,7 @@ export class Level2 {
       this.bossFlee = true;
     }
     if (this.bossFlee) {
-      this.boss.x += speed;
+      this.boss.x += move;
       if (this.boss.x > this.game.canvas.width) {
         this.game.gameOver = true;
         this.game.win = true;

--- a/src/player.js
+++ b/src/player.js
@@ -31,12 +31,12 @@ export class Player {
 
   jump() {
     if (!this.jumping) {
-      this.vy = -12;
+      this.vy = -720;
       this.jumping = true;
     }
   }
 
-  activateShield(duration = 15, cooldown = 60) {
+  activateShield(duration = 0.25, cooldown = 1) {
     if (!this.shieldActive && this.shieldCooldown === 0) {
       this.shieldActive = true;
       this.shieldTimer = duration;


### PR DESCRIPTION
## Summary
- Apply delta-time based physics and scoring so game speed is independent of frame rate
- Convert player jump and shield timers to real seconds
- Update level logic to use per-second intervals and velocities

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68aa15d853f4832c97b75caadf3940f4