### PR TITLE
Detach input listeners when resetting game

### DIFF
--- a/game.test.js
+++ b/game.test.js
@@ -49,6 +49,7 @@ function createStubGame() {
     removeEventListener: noop,
     requestAnimationFrame: noop,
   };
+  global.requestAnimationFrame = noop;
 
   const game = new Game(canvas);
   game.gamePaused = false;
@@ -78,4 +79,16 @@ test('resets when action is triggered after game over', () => {
   game.gamePaused = true;
   game.handleInput();
   assert.ok(resetCalled);
+});
+
+test('detaches and reattaches input listeners on reset', () => {
+  const game = createStubGame();
+  let detachCalls = 0;
+  let attachCalls = 0;
+  game.input.detach = () => { detachCalls++; };
+  game.input.attach = () => { attachCalls++; };
+  game.showOverlay = (_text, onClose) => { if (onClose) onClose(); };
+  game.reset();
+  assert.strictEqual(detachCalls, 1);
+  assert.strictEqual(attachCalls, 1);
 });

--- a/src/game.js
+++ b/src/game.js
@@ -86,6 +86,7 @@ export class Game {
   }
 
   reset() {
+    this.input.detach();
     this.resizeCanvas();
     this.score = 0;
     this.coins = 0;
@@ -97,6 +98,7 @@ export class Game {
     this.showOverlay(this.instructionsText[this.levelNumber], () => {
       this.gamePaused = false;
       this.lastTime = 0;
+      this.input.attach();
       requestAnimationFrame(ts => this.loop(ts));
     });
   }
@@ -136,6 +138,7 @@ export class Game {
     if (!this.gameOver && !this.gamePaused) {
       requestAnimationFrame(ts => this.loop(ts));
     } else if (this.gameOver && this.win) {
+      this.input.detach();
       this.showOverlay(this.storyText[2], () => { this.gamePaused = false; });
     }
   }


### PR DESCRIPTION
## Summary
- detach input listeners before resetting the game and reattach after overlay closes
- clean up listeners after a winning game
- add test ensuring input handlers are detached and reattached on reset

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68aa16f8f864832c8a39b2f445e86f46