### PR TITLE
feat: inject RNG for deterministic level spawns

### DIFF
--- a/deterministic.test.js
+++ b/deterministic.test.js
@@ -1,0 +1,86 @@
+import test from 'node:test';
+import assert from 'node:assert';
+import { Game } from './src/game.js';
+
+const FRAME = 1 / 60;
+
+function createStubGame(rng) {
+  const noop = () => {};
+  const ctx = {
+    clearRect: noop,
+    fillRect: noop,
+    beginPath: noop,
+    moveTo: noop,
+    lineTo: noop,
+    fill: noop,
+    arc: noop,
+    stroke: noop,
+    fillText: noop,
+    measureText: () => ({ width: 0 }),
+  };
+  const canvas = { width: 800, height: 200, getContext: () => ctx };
+  const overlay = { classList: { add: noop, remove: noop } };
+  const overlayContent = { textContent: '' };
+  const overlayButton = { onclick: null };
+
+  global.document = {
+    getElementById: (id) => {
+      switch (id) {
+        case 'game':
+          return canvas;
+        case 'overlay':
+          return overlay;
+        case 'overlay-content':
+          return overlayContent;
+        case 'overlay-button':
+          return overlayButton;
+        default:
+          return null;
+      }
+    },
+    addEventListener: noop,
+    removeEventListener: noop,
+  };
+  global.window = {
+    innerWidth: 800,
+    location: { search: '' },
+    addEventListener: noop,
+    removeEventListener: noop,
+    requestAnimationFrame: noop,
+  };
+
+  const game = new Game(canvas, rng);
+  game.showOverlay = noop;
+  game.gamePaused = false;
+  return game;
+}
+
+function seededRandom(seed) {
+  let s = seed;
+  return function () {
+    s |= 0;
+    s = (s + 0x6d2b79f5) | 0;
+    let t = Math.imul(s ^ (s >>> 15), 1 | s);
+    t ^= t + Math.imul(t ^ (t >>> 7), 61 | t);
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+  };
+}
+
+test('level 1 obstacle intervals are deterministic with seeded RNG', () => {
+  const rng1 = seededRandom(42);
+  const game1 = createStubGame(rng1);
+  const rng2 = seededRandom(42);
+  const game2 = createStubGame(rng2);
+
+  const level1 = game1.level;
+  const level2 = game2.level;
+
+  assert.strictEqual(level1.interval, level2.interval);
+
+  level1.timer = level1.interval;
+  level2.timer = level2.interval;
+  level1.update(FRAME);
+  level2.update(FRAME);
+
+  assert.strictEqual(level1.interval, level2.interval);
+});

--- a/src/game.js
+++ b/src/game.js
@@ -10,12 +10,13 @@ import {
 } from './config.js';
 
 export class Game {
-  constructor(canvas) {
+  constructor(canvas, randomFn = Math.random) {
     this.canvas = canvas;
     this.ctx = canvas.getContext('2d');
     this.overlay = document.getElementById('overlay');
     this.overlayContent = document.getElementById('overlay-content');
     this.overlayButton = document.getElementById('overlay-button');
+    this.random = randomFn;
 
     this.speed = GAME_SPEED; // pixels per second
     this.gravity = GRAVITY; // acceleration per second^2
@@ -33,7 +34,7 @@ export class Game {
     this.resizeCanvas();
 
     this.player = new Player(50, this.groundY);
-    this.level = this.levelNumber === 1 ? new Level1(this) : new Level2(this);
+    this.level = this.levelNumber === 1 ? new Level1(this, this.random) : new Level2(this, this.random);
     this.renderer = new Renderer(this);
 
     this.input = new InputHandler(() => this.handleInput());
@@ -98,7 +99,7 @@ export class Game {
     this.gameOver = false;
     this.win = false;
     this.player = new Player(50, this.groundY);
-    this.level = this.levelNumber === 1 ? new Level1(this) : new Level2(this);
+    this.level = this.levelNumber === 1 ? new Level1(this, this.random) : new Level2(this, this.random);
     this.gamePaused = true;
     this.showOverlay(this.instructionsText[this.levelNumber], () => {
       this.gamePaused = false;
@@ -116,7 +117,7 @@ export class Game {
     if (this.levelNumber === 1 && this.score >= LEVEL_UP_SCORE) {
       this.levelNumber = 2;
       this.player = new Player(50, this.groundY);
-      this.level = new Level2(this);
+      this.level = new Level2(this, this.random);
       this.gamePaused = true;
       this.showOverlay(this.storyText[1], () => {
         this.showOverlay(this.instructionsText[2], () => {

--- a/src/levels/level1.js
+++ b/src/levels/level1.js
@@ -2,15 +2,16 @@ import { Obstacle } from '../obstacle.js';
 import { isColliding } from '../../collision.js';
 
 export class Level1 {
-  constructor(game) {
+  constructor(game, random = Math.random) {
     this.game = game;
+    this.random = random;
     this.obstacles = [];
     this.timer = 0;
-    this.interval = Level1.getInterval();
+    this.interval = Level1.getInterval(this.random);
   }
 
-  static getInterval() {
-    return (80 + Math.random() * 70) / 60; // seconds
+  static getInterval(random) {
+    return (80 + random() * 70) / 60; // seconds
   }
 
   update(delta) {
@@ -25,7 +26,7 @@ export class Level1 {
       obstacle.coinAwarded = false;
       this.obstacles.push(obstacle);
       this.timer = 0;
-      this.interval = Level1.getInterval();
+      this.interval = Level1.getInterval(this.random);
     }
     this.obstacles.forEach(o => {
       o.update(this.game.speed * delta);

--- a/src/levels/level2.js
+++ b/src/levels/level2.js
@@ -2,8 +2,9 @@ import { Obstacle } from '../obstacle.js';
 import { isColliding } from '../../collision.js';
 
 export class Level2 {
-  constructor(game) {
+  constructor(game, random = Math.random) {
     this.game = game;
+    this.random = random;
     this.walls = [];
     this.wallTimer = 0;
     this.wallInterval = 90 / 60; // seconds
@@ -21,7 +22,7 @@ export class Level2 {
     if (this.wallTimer > this.wallInterval && !this.bossFlee) {
       this.walls.push(new Obstacle(this.boss.x, this.game.groundY, 30, 50));
       this.wallTimer = 0;
-      this.wallInterval = (60 + Math.random() * 60) / 60;
+      this.wallInterval = (60 + this.random() * 60) / 60;
     }
 
     this.walls.forEach(w => w.update(move));


### PR DESCRIPTION
## Summary
- allow injecting a random generator into the Game and level classes
- use injected RNG for obstacle spawn intervals in level 1 and wall intervals in level 2
- test deterministic behaviour with a seeded RNG

## Testing
- `node --test`


------
https://chatgpt.com/codex/tasks/task_e_68aa1c632f40832ca03432e4825ac1cf