### PR TITLE
refactor tests: extract DOM setup helper

### DIFF
--- a/coins.test.js
+++ b/coins.test.js
@@ -1,63 +1,11 @@
 import test from 'node:test';
 import assert from 'node:assert';
-import { Game } from './src/game.js';
+import { createStubGame } from './testHelpers.js';
 import { Obstacle } from './src/obstacle.js';
 import { Level2 } from './src/levels/level2.js';
 import { LEVEL_UP_SCORE } from './src/config.js';
 
 const FRAME = 1 / 60;
-
-function createStubGame() {
-  const noop = () => {};
-  const ctx = {
-    clearRect: noop,
-    fillRect: noop,
-    beginPath: noop,
-    moveTo: noop,
-    lineTo: noop,
-    fill: noop,
-    arc: noop,
-    stroke: noop,
-    fillText: noop,
-    measureText: () => ({ width: 0 }),
-  };
-  const canvas = { width: 800, height: 200, getContext: () => ctx };
-  const overlay = { classList: { add: noop, remove: noop } };
-  const overlayContent = {};
-  const overlayButton = {};
-
-  global.document = {
-    getElementById: (id) => {
-      switch (id) {
-        case 'game':
-          return canvas;
-        case 'overlay':
-          return overlay;
-        case 'overlay-content':
-          return overlayContent;
-        case 'overlay-button':
-          return overlayButton;
-        default:
-          return null;
-      }
-    },
-    addEventListener: noop,
-    removeEventListener: noop,
-  };
-
-  global.window = {
-    innerWidth: 800,
-    location: { search: '' },
-    addEventListener: noop,
-    removeEventListener: noop,
-    requestAnimationFrame: noop,
-  };
-
-  const game = new Game(canvas);
-  game.showOverlay = noop;
-  game.gamePaused = false;
-  return game;
-}
 
 test('awards coin for passed obstacle and preserves coins in level 2', () => {
   const game = createStubGame();

--- a/deterministic.test.js
+++ b/deterministic.test.js
@@ -1,59 +1,8 @@
 import test from 'node:test';
 import assert from 'node:assert';
-import { Game } from './src/game.js';
+import { createStubGame } from './testHelpers.js';
 
 const FRAME = 1 / 60;
-
-function createStubGame(rng) {
-  const noop = () => {};
-  const ctx = {
-    clearRect: noop,
-    fillRect: noop,
-    beginPath: noop,
-    moveTo: noop,
-    lineTo: noop,
-    fill: noop,
-    arc: noop,
-    stroke: noop,
-    fillText: noop,
-    measureText: () => ({ width: 0 }),
-  };
-  const canvas = { width: 800, height: 200, getContext: () => ctx };
-  const overlay = { classList: { add: noop, remove: noop } };
-  const overlayContent = { textContent: '' };
-  const overlayButton = { onclick: null };
-
-  global.document = {
-    getElementById: (id) => {
-      switch (id) {
-        case 'game':
-          return canvas;
-        case 'overlay':
-          return overlay;
-        case 'overlay-content':
-          return overlayContent;
-        case 'overlay-button':
-          return overlayButton;
-        default:
-          return null;
-      }
-    },
-    addEventListener: noop,
-    removeEventListener: noop,
-  };
-  global.window = {
-    innerWidth: 800,
-    location: { search: '' },
-    addEventListener: noop,
-    removeEventListener: noop,
-    requestAnimationFrame: noop,
-  };
-
-  const game = new Game(canvas, rng);
-  game.showOverlay = noop;
-  game.gamePaused = false;
-  return game;
-}
 
 function seededRandom(seed) {
   let s = seed;
@@ -68,9 +17,9 @@ function seededRandom(seed) {
 
 test('level 1 obstacle intervals are deterministic with seeded RNG', () => {
   const rng1 = seededRandom(42);
-  const game1 = createStubGame(rng1);
+  const game1 = createStubGame({ rng: rng1 });
   const rng2 = seededRandom(42);
-  const game2 = createStubGame(rng2);
+  const game2 = createStubGame({ rng: rng2 });
 
   const level1 = game1.level;
   const level2 = game2.level;

--- a/game.test.js
+++ b/game.test.js
@@ -1,66 +1,13 @@
 import test from 'node:test';
 import assert from 'node:assert';
-import { Game } from './src/game.js';
+import { createStubGame } from './testHelpers.js';
 import { Level2 } from './src/levels/level2.js';
 import { LEVEL_UP_SCORE } from './src/config.js';
 
 const FRAME = 1 / 60;
 
-function createStubGame() {
-  const noop = () => {};
-  const ctx = {
-    clearRect: noop,
-    fillRect: noop,
-    beginPath: noop,
-    moveTo: noop,
-    lineTo: noop,
-    fill: noop,
-    arc: noop,
-    stroke: noop,
-    fillText: noop,
-    measureText: () => ({ width: 0 }),
-  };
-  const canvas = { width: 800, height: 200, getContext: () => ctx };
-  const overlay = { classList: { add: noop, remove: noop } };
-  const overlayContent = {};
-  const overlayButton = {};
-
-  global.document = {
-    getElementById: (id) => {
-      switch (id) {
-        case 'game':
-          return canvas;
-        case 'overlay':
-          return overlay;
-        case 'overlay-content':
-          return overlayContent;
-        case 'overlay-button':
-          return overlayButton;
-        default:
-          return null;
-      }
-    },
-    addEventListener: noop,
-    removeEventListener: noop,
-  };
-  global.window = {
-    innerWidth: 800,
-    location: { search: '' },
-    addEventListener: noop,
-    removeEventListener: noop,
-    requestAnimationFrame: noop,
-  };
-  global.requestAnimationFrame = noop;
-
-  const game = new Game(canvas);
-  game.gamePaused = false;
-  game.showOverlay = noop;
-  game.level.update = noop;
-  return game;
-}
-
 test('advances to level 2 after reaching threshold points', () => {
-  const game = createStubGame();
+  const game = createStubGame({ skipLevelUpdate: true });
   for (let i = 0; i < LEVEL_UP_SCORE - 1; i++) {
     game.update(FRAME);
   }
@@ -71,7 +18,7 @@ test('advances to level 2 after reaching threshold points', () => {
 });
 
 test('resets when action is triggered after game over', () => {
-  const game = createStubGame();
+  const game = createStubGame({ skipLevelUpdate: true });
   let resetCalled = false;
   game.reset = () => {
     resetCalled = true;
@@ -83,7 +30,7 @@ test('resets when action is triggered after game over', () => {
 });
 
 test('detaches and reattaches input listeners on reset', () => {
-  const game = createStubGame();
+  const game = createStubGame({ skipLevelUpdate: true });
   let detachCalls = 0;
   let attachCalls = 0;
   game.input.detach = () => { detachCalls++; };

--- a/level2.test.js
+++ b/level2.test.js
@@ -1,64 +1,12 @@
 import test from 'node:test';
 import assert from 'node:assert';
-import { Game } from './src/game.js';
+import { createStubGame } from './testHelpers.js';
 import { Level2 } from './src/levels/level2.js';
 
 const FRAME = 1 / 60;
 
-function createStubGame({ canvasWidth = 800, innerWidth = 800, search = '' } = {}) {
-  const noop = () => {};
-  const ctx = {
-    clearRect: noop,
-    fillRect: noop,
-    beginPath: noop,
-    moveTo: noop,
-    lineTo: noop,
-    fill: noop,
-    arc: noop,
-    stroke: noop,
-    fillText: noop,
-    measureText: () => ({ width: 0 }),
-  };
-  const canvas = { width: canvasWidth, height: 200, getContext: () => ctx };
-  const overlay = { classList: { add: noop, remove: noop } };
-  const overlayContent = { textContent: '' };
-  const overlayButton = { onclick: null };
-
-  global.document = {
-    getElementById: (id) => {
-      switch (id) {
-        case 'game':
-          return canvas;
-        case 'overlay':
-          return overlay;
-        case 'overlay-content':
-          return overlayContent;
-        case 'overlay-button':
-          return overlayButton;
-        default:
-          return null;
-      }
-    },
-    addEventListener: noop,
-    removeEventListener: noop,
-  };
-  global.window = {
-    innerWidth,
-    location: { search },
-    addEventListener: noop,
-    removeEventListener: noop,
-    requestAnimationFrame: noop,
-  };
-
-  const game = new Game(canvas);
-  game.showOverlay = noop;
-  game.gamePaused = false;
-  game.level.update = noop;
-  return game;
-}
-
 test('boss flees after player covers 70% of distance', () => {
-  const game = createStubGame();
+  const game = createStubGame({ skipLevelUpdate: true });
   const level = new Level2(game);
   const initialDistance = level.boss.x - (game.player.x + game.player.width);
   const threshold = initialDistance * 0.3;
@@ -69,7 +17,7 @@ test('boss flees after player covers 70% of distance', () => {
 });
 
 test('boss does not flee before player covers 70% of distance', () => {
-  const game = createStubGame();
+  const game = createStubGame({ skipLevelUpdate: true });
   const level = new Level2(game);
   const initialDistance = level.boss.x - (game.player.x + game.player.width);
   const almostThreshold = initialDistance * 0.31;
@@ -80,13 +28,13 @@ test('boss does not flee before player covers 70% of distance', () => {
 });
 
 test('boss initial position uses resized canvas width', () => {
-  const game = createStubGame({ canvasWidth: 300, innerWidth: 800, search: '?level=2' });
+  const game = createStubGame({ canvasWidth: 300, innerWidth: 800, search: '?level=2', skipLevelUpdate: true });
   assert.strictEqual(game.canvas.width, 800);
   assert.strictEqual(game.level.boss.x, 700);
 });
 
 test('shield deactivates even when input is spammed', () => {
-  const game = createStubGame({ search: '?level=2' });
+  const game = createStubGame({ search: '?level=2', skipLevelUpdate: true });
   const player = game.player;
   for (let i = 0; i < 30; i++) {
     game.handleInput();
@@ -96,7 +44,7 @@ test('shield deactivates even when input is spammed', () => {
 });
 
 test('shield can be reactivated after cooldown', () => {
-  const game = createStubGame({ search: '?level=2' });
+  const game = createStubGame({ search: '?level=2', skipLevelUpdate: true });
   const player = game.player;
   game.handleInput();
   for (let i = 0; i < 60; i++) {

--- a/testHelpers.js
+++ b/testHelpers.js
@@ -1,0 +1,62 @@
+import { Game } from './src/game.js';
+
+export function createStubGame({
+  rng,
+  canvasWidth = 800,
+  innerWidth = 800,
+  search = '',
+  skipLevelUpdate = false,
+} = {}) {
+  const noop = () => {};
+  const ctx = {
+    clearRect: noop,
+    fillRect: noop,
+    beginPath: noop,
+    moveTo: noop,
+    lineTo: noop,
+    fill: noop,
+    arc: noop,
+    stroke: noop,
+    fillText: noop,
+    measureText: () => ({ width: 0 }),
+  };
+  const canvas = { width: canvasWidth, height: 200, getContext: () => ctx };
+  const overlay = { classList: { add: noop, remove: noop } };
+  const overlayContent = { textContent: '' };
+  const overlayButton = { onclick: null };
+
+  global.document = {
+    getElementById: (id) => {
+      switch (id) {
+        case 'game':
+          return canvas;
+        case 'overlay':
+          return overlay;
+        case 'overlay-content':
+          return overlayContent;
+        case 'overlay-button':
+          return overlayButton;
+        default:
+          return null;
+      }
+    },
+    addEventListener: noop,
+    removeEventListener: noop,
+  };
+  global.window = {
+    innerWidth,
+    location: { search },
+    addEventListener: noop,
+    removeEventListener: noop,
+    requestAnimationFrame: noop,
+  };
+  global.requestAnimationFrame = noop;
+
+  const game = new Game(canvas, rng);
+  game.showOverlay = noop;
+  game.gamePaused = false;
+  if (skipLevelUpdate) {
+    game.level.update = noop;
+  }
+  return game;
+}


### PR DESCRIPTION
## Summary
- add `createStubGame` helper to build fake DOM and canvas
- update unit tests to reuse shared stub instead of duplicating setup

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68aa1d7f046c832cb2e77c3ef14b74ab