### PR TITLE
Fix unicorn jump landing by increasing gravity

### DIFF
--- a/landing.test.js
+++ b/landing.test.js
@@ -1,0 +1,18 @@
+import test from 'node:test';
+import assert from 'node:assert';
+import { createStubGame } from './testHelpers.js';
+
+const FRAME = 1 / 60;
+
+test('player lands within one second after jumping', () => {
+  const game = createStubGame({ skipLevelUpdate: true });
+  const { player, groundY } = game;
+
+  player.jump();
+  for (let i = 0; i < 60; i++) {
+    game.update(FRAME);
+  }
+
+  assert.strictEqual(player.y, groundY);
+  assert.ok(!player.jumping);
+});

--- a/src/config.js
+++ b/src/config.js
@@ -1,4 +1,5 @@
 export const GAME_SPEED = 180;
-export const GRAVITY = 24;
+// Increased gravity so the player lands quickly after jumping.
+export const GRAVITY = 2400;
 export const LEVEL_UP_SCORE = 1000;
 export const JUMP_VELOCITY = -720;


### PR DESCRIPTION
## Summary
- Increase gravity so the player returns to ground quickly after jumping
- Add test verifying the player lands within one second of a jump

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68aa1edd34a4832c9c328ca459b4208a