### PR TITLE
Adjust canvas height to avoid scrolling on mobile

### DIFF
--- a/src/game.js
+++ b/src/game.js
@@ -69,7 +69,17 @@ export class Game {
 
   resizeCanvas() {
     this.canvas.width = window.innerWidth;
-    this.canvas.height = window.innerHeight || this.canvas.height;
+    // Ensure the canvas fits in the remaining viewport height so the
+    // player is visible without scrolling, especially on mobile devices.
+    let availableHeight = window.innerHeight || this.canvas.height;
+    if (
+      typeof window.innerHeight === 'number' &&
+      typeof this.canvas.getBoundingClientRect === 'function'
+    ) {
+      const rect = this.canvas.getBoundingClientRect();
+      availableHeight = window.innerHeight - rect.top;
+    }
+    this.canvas.height = availableHeight > 0 ? availableHeight : this.canvas.height;
     this.groundY = this.canvas.height - 50;
     if (this.player && !this.player.jumping) {
       this.player.y = this.groundY;


### PR DESCRIPTION
## Summary
- Ensure the game canvas fits within the visible viewport by subtracting its offset from the window height
- Prevent scrolling issues on mobile and maintain safe fallback when DOM APIs are absent

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68aa3e679b5c832c9f2617530b480eea