### PR TITLE
Refactor overlay logic into reusable module

### DIFF
--- a/main.js
+++ b/main.js
@@ -1,5 +1,6 @@
 import { Game } from './src/game.js';
 import { LEVEL_UP_SCORE } from './src/config.js';
+import { Overlay } from './src/overlay.js';
 
 window.addEventListener('DOMContentLoaded', () => {
   const canvas = document.getElementById('game');
@@ -7,9 +8,7 @@ window.addEventListener('DOMContentLoaded', () => {
   const playButton = document.getElementById('play-button');
   const instructionsButton = document.getElementById('instructions-button');
   const creditsButton = document.getElementById('credits-button');
-  const overlay = document.getElementById('overlay');
-  const overlayContent = document.getElementById('overlay-content');
-  const overlayButton = document.getElementById('overlay-button');
+  const overlay = new Overlay();
 
   let game;
   playButton.addEventListener('click', () => {
@@ -22,23 +21,19 @@ window.addEventListener('DOMContentLoaded', () => {
     }
   });
 
-  const showSimpleOverlay = (text) => {
-    overlayContent.textContent = text;
-    overlayButton.textContent = 'Indietro';
-    overlay.classList.remove('hidden');
-    overlayButton.onclick = () => {
-      overlay.classList.add('hidden');
-      overlayButton.onclick = null;
-    };
-  };
-
   instructionsButton.addEventListener('click', () => {
-    showSimpleOverlay(
-      `Premi la barra spaziatrice o tocca lo schermo per saltare. Raggiungi ${LEVEL_UP_SCORE} punti e supera il Cavaliere Nero per vincere!`
+    overlay.show(
+      `Premi la barra spaziatrice o tocca lo schermo per saltare. Raggiungi ${LEVEL_UP_SCORE} punti e supera il Cavaliere Nero per vincere!`,
+      null,
+      'Indietro'
     );
   });
 
   creditsButton.addEventListener('click', () => {
-    showSimpleOverlay("Gioco realizzato quasi interamente con l'aiuto di ChatGPT.");
+    overlay.show(
+      "Gioco realizzato quasi interamente con l'aiuto di ChatGPT.",
+      null,
+      'Indietro'
+    );
   });
 });

--- a/src/overlay.js
+++ b/src/overlay.js
@@ -3,15 +3,22 @@ export class Overlay {
     this.element = document.getElementById('overlay');
     this.content = document.getElementById('overlay-content');
     this.button = document.getElementById('overlay-button');
+    this.defaultButtonText = this.button.textContent;
+    this.onClose = null;
+    this.button.addEventListener('click', () => this.hide());
   }
 
-  show(text, onClose) {
+  show(text, onClose, buttonText = this.defaultButtonText) {
     this.content.textContent = text;
+    this.button.textContent = buttonText;
+    this.onClose = onClose;
     this.element.classList.remove('hidden');
-    this.button.onclick = () => {
-      this.element.classList.add('hidden');
-      this.button.onclick = null;
-      if (onClose) onClose();
-    };
+  }
+
+  hide() {
+    this.element.classList.add('hidden');
+    const cb = this.onClose;
+    this.onClose = null;
+    if (cb) cb();
   }
 }

--- a/testHelpers.js
+++ b/testHelpers.js
@@ -23,7 +23,7 @@ export function createStubGame({
   const canvas = { width: canvasWidth, height: 200, getContext: () => ctx };
   const overlay = { classList: { add: noop, remove: noop } };
   const overlayContent = { textContent: '' };
-  const overlayButton = { onclick: null };
+  const overlayButton = { onclick: null, textContent: '', addEventListener: noop };
 
   global.document = {
     getElementById: (id) => {


### PR DESCRIPTION
## Summary
- encapsulate overlay show/hide behavior in dedicated class with persistent click handler
- use overlay module in main menu instead of inline handlers
- update test helpers for new overlay implementation

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68aa44501f5c832c88699734456ad4d7