### PR TITLE
Improve canvas resize handling

### DIFF
--- a/game.test.js
+++ b/game.test.js
@@ -40,3 +40,23 @@ test('detaches and reattaches input listeners on reset', () => {
   assert.strictEqual(detachCalls, 1);
   assert.strictEqual(attachCalls, 1);
 });
+
+test('removes resize listener on destroy', () => {
+  const game = createStubGame({ skipLevelUpdate: true });
+  assert.ok(window._eventListeners.resize);
+  game.destroy();
+  assert.strictEqual(window._eventListeners.resize, undefined);
+});
+
+test('throttles resize events', async () => {
+  const game = createStubGame({ skipLevelUpdate: true });
+  let calls = 0;
+  game.resizeCanvas = () => { calls++; };
+  window.dispatchEvent({ type: 'resize' });
+  window.dispatchEvent({ type: 'resize' });
+  window.dispatchEvent({ type: 'resize' });
+  assert.strictEqual(calls, 0);
+  await new Promise(r => setTimeout(r, 250));
+  assert.strictEqual(calls, 1);
+  game.destroy();
+});

--- a/src/game.js
+++ b/src/game.js
@@ -30,7 +30,8 @@ export class Game {
     this.params = new URLSearchParams(window.location.search);
     this.levelNumber = this.params.get('level') === '2' ? 2 : 1;
 
-    window.addEventListener('resize', () => this.resizeCanvas());
+    this.boundResize = this.throttle(() => this.resizeCanvas(), 200);
+    window.addEventListener('resize', this.boundResize);
     this.resizeCanvas();
 
     this.player = new Player(50, this.groundY);
@@ -49,6 +50,17 @@ export class Game {
 
   showOverlay(text, onClose) {
     this.overlay.show(text, onClose);
+  }
+
+  throttle(fn, delay) {
+    let timeoutId = null;
+    return (...args) => {
+      if (timeoutId !== null) return;
+      timeoutId = setTimeout(() => {
+        timeoutId = null;
+        fn(...args);
+      }, delay);
+    };
   }
 
   resizeCanvas() {
@@ -141,5 +153,9 @@ export class Game {
       this.input.detach();
       this.showOverlay(STORY_TEXT[2], () => { this.gamePaused = false; });
     }
+  }
+
+  destroy() {
+    window.removeEventListener('resize', this.boundResize);
   }
 }

--- a/testHelpers.js
+++ b/testHelpers.js
@@ -43,12 +43,22 @@ export function createStubGame({
     addEventListener: noop,
     removeEventListener: noop,
   };
+  const eventListeners = {};
   global.window = {
     innerWidth,
     location: { search },
-    addEventListener: noop,
-    removeEventListener: noop,
+    addEventListener: (event, handler) => {
+      eventListeners[event] = handler;
+    },
+    removeEventListener: (event, handler) => {
+      if (eventListeners[event] === handler) delete eventListeners[event];
+    },
+    dispatchEvent: (event) => {
+      const handler = eventListeners[event.type];
+      if (handler) handler(event);
+    },
     requestAnimationFrame: noop,
+    _eventListeners: eventListeners,
   };
   global.requestAnimationFrame = noop;
 


### PR DESCRIPTION
## Summary
- Throttle canvas resize handling and make listener removable
- Add helper utilities for tracking window events in tests
- Test resize event throttling and cleanup

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68aa46c0d834832c9033ec3f995ce94c