### PR TITLE
feat: throttle canvas resize

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -3,3 +3,5 @@ export const GAME_SPEED = 180;
 export const GRAVITY = 1800;
 export const LEVEL_UP_SCORE = 1000;
 export const JUMP_VELOCITY = -720;
+// Delay between canvas resize adjustments (ms)
+export const RESIZE_THROTTLE_MS = 200;

--- a/src/game.js
+++ b/src/game.js
@@ -9,6 +9,7 @@ import {
   GAME_SPEED,
   GRAVITY,
   LEVEL_UP_SCORE,
+  RESIZE_THROTTLE_MS,
 } from './config.js';
 
 export class Game {
@@ -30,7 +31,7 @@ export class Game {
     this.params = new URLSearchParams(window.location.search);
     this.levelNumber = this.params.get('level') === '2' ? 2 : 1;
 
-    this.boundResize = this.throttle(() => this.resizeCanvas(), 200);
+    this.boundResize = this.throttle(() => this.resizeCanvas(), RESIZE_THROTTLE_MS);
     window.addEventListener('resize', this.boundResize);
     this.resizeCanvas();
 
@@ -157,5 +158,6 @@ export class Game {
 
   destroy() {
     window.removeEventListener('resize', this.boundResize);
+    this.boundResize = null;
   }
 }


### PR DESCRIPTION
## Summary
- make resize throttling configurable via RESIZE_THROTTLE_MS
- clean up resize listener on game destroy

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68aa48b0e290832c9ca7ab84ac2ff4d2