### PR TITLE
Render walls using sprite image

### DIFF
--- a/src/renderer.js
+++ b/src/renderer.js
@@ -31,6 +31,7 @@ export class Renderer {
         load('sprites/enemies/black_knight/run/02.png'),
         load('sprites/enemies/black_knight/run/03.png'),
       ];
+      this.wallSprite = load('sprites/projectiles/wall/00.png');
     }
     this.playerFrameIndex = 0;
     this.playerFrameTimer = 0;
@@ -121,10 +122,16 @@ export class Renderer {
   drawWalls() {
     const { game } = this;
     this.withContext(ctx => {
-      ctx.fillStyle = 'gray';
-      game.level.walls.forEach(w => {
-        ctx.fillRect(w.x, w.y - w.height, w.width, w.height);
-      });
+      if (this.wallSprite) {
+        game.level.walls.forEach(w => {
+          ctx.drawImage(this.wallSprite, w.x, w.y - w.height, w.width, w.height);
+        });
+      } else {
+        ctx.fillStyle = 'gray';
+        game.level.walls.forEach(w => {
+          ctx.fillRect(w.x, w.y - w.height, w.width, w.height);
+        });
+      }
       const b = game.level.boss;
       if (this.knightSprites) {
         const now = typeof performance !== 'undefined' ? performance.now() : Date.now();


### PR DESCRIPTION
## Summary
- Load wall sprite image in renderer
- Render walls using the sprite instead of gray rectangles

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68aa49219304832cb96ce6930115782d