### PR TITLE
feat: add passive listeners and customizable input

### DIFF
--- a/input.test.js
+++ b/input.test.js
@@ -1,0 +1,34 @@
+import test from 'node:test';
+import assert from 'node:assert';
+import { InputHandler } from './src/input.js';
+
+test('attaches listeners with passive option by default', () => {
+  const calls = [];
+  global.document = {
+    addEventListener: (type, listener, options) => {
+      calls.push({ target: 'document', type, options });
+    },
+    removeEventListener: () => {},
+  };
+  global.window = {
+    addEventListener: (type, listener, options) => {
+      calls.push({ target: 'window', type, options });
+    },
+    removeEventListener: () => {},
+  };
+  const handler = new InputHandler(() => {});
+  handler.attach();
+  assert.deepStrictEqual(calls, [
+    { target: 'document', type: 'keydown', options: { passive: true } },
+    { target: 'window', type: 'pointerdown', options: { passive: true } },
+  ]);
+});
+
+test('supports custom key mappings', () => {
+  let count = 0;
+  const handler = new InputHandler(() => count++, { keys: ['KeyA', 'KeyB'] });
+  handler.keyListener({ code: 'KeyA', repeat: false });
+  handler.keyListener({ code: 'KeyB', repeat: false });
+  handler.keyListener({ code: 'Space', repeat: false });
+  assert.strictEqual(count, 2);
+});

--- a/src/input.js
+++ b/src/input.js
@@ -1,19 +1,32 @@
 export class InputHandler {
-  constructor(onAction) {
+  constructor(
+    onAction,
+    { keys = ['Space'], pointerEvent = 'pointerdown', passive = true } = {}
+  ) {
     this.onAction = onAction;
+    this.keys = keys;
+    this.pointerEvent = pointerEvent;
+    this.eventOptions = passive ? { passive: true } : undefined;
+
     this.keyListener = (e) => {
-      if (e.code === 'Space' && !e.repeat) this.onAction();
+      if (this.keys.includes(e.code) && !e.repeat) this.onAction();
     };
     this.pointerListener = () => this.onAction();
   }
 
   attach() {
-    document.addEventListener('keydown', this.keyListener);
-    window.addEventListener('pointerdown', this.pointerListener);
+    document.addEventListener('keydown', this.keyListener, this.eventOptions);
+    if (this.pointerEvent)
+      window.addEventListener(this.pointerEvent, this.pointerListener, this.eventOptions);
   }
 
   detach() {
-    document.removeEventListener('keydown', this.keyListener);
-    window.removeEventListener('pointerdown', this.pointerListener);
+    document.removeEventListener('keydown', this.keyListener, this.eventOptions);
+    if (this.pointerEvent)
+      window.removeEventListener(
+        this.pointerEvent,
+        this.pointerListener,
+        this.eventOptions
+      );
   }
 }


### PR DESCRIPTION
## Summary
- allow InputHandler to accept custom key mappings and pointer events
- attach input listeners with passive option to reduce scroll overhead
- add tests for passive listeners and custom key support

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68aa4a0ce67c832cb20e2fef90d62892