### PR TITLE
feat: preload game assets with asset manager

### DIFF
--- a/src/assetManager.js
+++ b/src/assetManager.js
@@ -1,0 +1,33 @@
+export class AssetManager {
+  constructor() {
+    this.assets = new Map();
+  }
+
+  loadImage(key, src) {
+    return new Promise((resolve, reject) => {
+      if (typeof Image === 'undefined') {
+        const img = { src };
+        this.assets.set(key, img);
+        resolve(img);
+        return;
+      }
+      const img = new Image();
+      img.onload = () => {
+        this.assets.set(key, img);
+        resolve(img);
+      };
+      img.onerror = () => {
+        reject(new Error(`Failed to load image: ${src}`));
+      };
+      img.src = src;
+    });
+  }
+
+  loadAll(list) {
+    return Promise.all(list.map(({ key, src }) => this.loadImage(key, src)));
+  }
+
+  get(key) {
+    return this.assets.get(key);
+  }
+}

--- a/src/game.js
+++ b/src/game.js
@@ -35,18 +35,27 @@ export class Game {
     window.addEventListener('resize', this.boundResize);
     this.resizeCanvas();
 
-    this.player = new Player(50, this.groundY);
-    this.level = this.levelNumber === 1 ? new Level1(this, this.random) : new Level2(this, this.random);
-    this.renderer = new Renderer(this);
+      this.player = new Player(50, this.groundY);
+      this.level = this.levelNumber === 1 ? new Level1(this, this.random) : new Level2(this, this.random);
+      this.renderer = new Renderer(this);
 
-    this.input = new InputHandler(() => this.handleInput());
-    this.input.attach();
+      this.input = new InputHandler(() => this.handleInput());
+      this.input.attach();
 
-    this.showOverlay(INSTRUCTIONS_TEXT[this.levelNumber], () => {
-      this.gamePaused = false;
-      this.lastTime = 0;
-      requestAnimationFrame(ts => this.loop(ts));
-    });
+      this.renderer.preload().then(() => {
+        this.showOverlay(INSTRUCTIONS_TEXT[this.levelNumber], () => {
+          this.gamePaused = false;
+          this.lastTime = 0;
+          requestAnimationFrame(ts => this.loop(ts));
+        });
+      }).catch(err => {
+        console.error(err);
+        this.showOverlay(INSTRUCTIONS_TEXT[this.levelNumber], () => {
+          this.gamePaused = false;
+          this.lastTime = 0;
+          requestAnimationFrame(ts => this.loop(ts));
+        });
+      });
   }
 
   showOverlay(text, onClose) {

--- a/src/renderer.js
+++ b/src/renderer.js
@@ -1,38 +1,14 @@
+import { AssetManager } from './assetManager.js';
+
 export class Renderer {
   constructor(game) {
     this.game = game;
     this.ctx = game.ctx;
-    if (typeof Image !== 'undefined') {
-      const load = src => {
-        const img = new Image();
-        img.src = src;
-        return img;
-      };
-      this.playerSprites = {
-        idle: [
-          load('sprites/player/princess/idle/00.png'),
-          load('sprites/player/princess/idle/01.png'),
-        ],
-        run: [
-          load('sprites/player/princess/run/00.png'),
-          load('sprites/player/princess/run/01.png'),
-          load('sprites/player/princess/run/02.png'),
-          load('sprites/player/princess/run/03.png'),
-        ],
-      };
-      this.treeSprites = [
-        load('sprites/obstacles/trees/00.png'),
-        load('sprites/obstacles/trees/01.png'),
-        load('sprites/obstacles/trees/02.png'),
-      ];
-      this.knightSprites = [
-        load('sprites/enemies/black_knight/run/00.png'),
-        load('sprites/enemies/black_knight/run/01.png'),
-        load('sprites/enemies/black_knight/run/02.png'),
-        load('sprites/enemies/black_knight/run/03.png'),
-      ];
-      this.wallSprite = load('sprites/projectiles/wall/00.png');
-    }
+    this.assets = new AssetManager();
+    this.playerSprites = null;
+    this.treeSprites = null;
+    this.knightSprites = null;
+    this.wallSprite = null;
     this.playerFrameIndex = 0;
     this.playerFrameTimer = 0;
     this.frameInterval = 0.1;
@@ -40,6 +16,54 @@ export class Renderer {
     this.knightFrameIndex = 0;
     this.knightFrameTimer = 0;
     this.lastKnightTime = 0;
+  }
+
+  preload() {
+    if (typeof Image === 'undefined') {
+      return Promise.resolve();
+    }
+    const assets = [
+      { key: 'player_idle_0', src: 'sprites/player/princess/idle/00.png' },
+      { key: 'player_idle_1', src: 'sprites/player/princess/idle/01.png' },
+      { key: 'player_run_0', src: 'sprites/player/princess/run/00.png' },
+      { key: 'player_run_1', src: 'sprites/player/princess/run/01.png' },
+      { key: 'player_run_2', src: 'sprites/player/princess/run/02.png' },
+      { key: 'player_run_3', src: 'sprites/player/princess/run/03.png' },
+      { key: 'tree_0', src: 'sprites/obstacles/trees/00.png' },
+      { key: 'tree_1', src: 'sprites/obstacles/trees/01.png' },
+      { key: 'tree_2', src: 'sprites/obstacles/trees/02.png' },
+      { key: 'knight_0', src: 'sprites/enemies/black_knight/run/00.png' },
+      { key: 'knight_1', src: 'sprites/enemies/black_knight/run/01.png' },
+      { key: 'knight_2', src: 'sprites/enemies/black_knight/run/02.png' },
+      { key: 'knight_3', src: 'sprites/enemies/black_knight/run/03.png' },
+      { key: 'wall', src: 'sprites/projectiles/wall/00.png' },
+    ];
+    return this.assets.loadAll(assets).then(() => {
+      this.playerSprites = {
+        idle: [
+          this.assets.get('player_idle_0'),
+          this.assets.get('player_idle_1'),
+        ],
+        run: [
+          this.assets.get('player_run_0'),
+          this.assets.get('player_run_1'),
+          this.assets.get('player_run_2'),
+          this.assets.get('player_run_3'),
+        ],
+      };
+      this.treeSprites = [
+        this.assets.get('tree_0'),
+        this.assets.get('tree_1'),
+        this.assets.get('tree_2'),
+      ];
+      this.knightSprites = [
+        this.assets.get('knight_0'),
+        this.assets.get('knight_1'),
+        this.assets.get('knight_2'),
+        this.assets.get('knight_3'),
+      ];
+      this.wallSprite = this.assets.get('wall');
+    });
   }
 
   withContext(drawFn) {


### PR DESCRIPTION
## Summary
- add `AssetManager` to preload image resources with error handling
- refactor renderer to load sprites through the asset manager
- defer game start until assets finish loading

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68aa4ace862c832cb310dfc87b14bc47