### PR TITLE
Add death animation and game over loop

### DIFF
--- a/src/game.js
+++ b/src/game.js
@@ -126,8 +126,11 @@ export class Game {
   }
 
   update(delta) {
-    this.player.update(this.gravity, this.groundY, delta);
+    this.player.update(this.gameOver ? 0 : this.gravity, this.groundY, delta);
     this.level.update(delta);
+    if (this.gameOver && !this.player.dead && !this.win) {
+      this.player.die();
+    }
     if (!this.gameOver) this.score += delta * 60;
 
     if (this.levelNumber === 1 && this.score >= LEVEL_UP_SCORE) {
@@ -157,11 +160,15 @@ export class Game {
     this.lastTime = timestamp;
     this.update(delta);
     this.draw();
-    if (!this.gameOver && !this.gamePaused) {
+    if (this.gameOver) {
+      if (this.win) {
+        this.input.detach();
+        this.showOverlay(STORY_TEXT[2], () => { this.gamePaused = false; });
+      } else {
+        requestAnimationFrame(ts => this.loop(ts));
+      }
+    } else if (!this.gamePaused) {
       requestAnimationFrame(ts => this.loop(ts));
-    } else if (this.gameOver && this.win) {
-      this.input.detach();
-      this.showOverlay(STORY_TEXT[2], () => { this.gamePaused = false; });
     }
   }
 

--- a/src/player.js
+++ b/src/player.js
@@ -11,6 +11,7 @@ export class Player {
     this.shieldActive = false;
     this.shieldTimer = 0;
     this.shieldCooldown = 0;
+    this.dead = false;
   }
 
   update(gravity, groundY, delta) {
@@ -44,5 +45,10 @@ export class Player {
       this.shieldTimer = duration;
       this.shieldCooldown = cooldown;
     }
+  }
+
+  die(speed = -200) {
+    this.dead = true;
+    this.vy = speed;
   }
 }


### PR DESCRIPTION
## Summary
- Make player fly upward on game over
- Continue rendering frames while game over for animation

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68aabc17a8a8832cab601947109a175c