### PR TITLE
Fix missing death animation after losing

### DIFF
--- a/game.test.js
+++ b/game.test.js
@@ -60,3 +60,14 @@ test('throttles resize events', async () => {
   assert.strictEqual(calls, 1);
   game.destroy();
 });
+
+test('player continues to fall after losing', () => {
+  const game = createStubGame({ search: '?level=2', skipLevelUpdate: true });
+  // Simulate a game over scenario and trigger the death animation
+  game.gameOver = true;
+  game.player.die();
+  const initialVy = game.player.vy;
+  // After update, gravity should increase the vertical velocity
+  game.update(FRAME);
+  assert.ok(game.player.vy > initialVy);
+});

--- a/src/game.js
+++ b/src/game.js
@@ -126,7 +126,9 @@ export class Game {
   }
 
   update(delta) {
-    this.player.update(this.gameOver ? 0 : this.gravity, this.groundY, delta);
+    // Always apply gravity after a loss so the death animation completes.
+    // Only skip gravity when the player has won, so they remain in place.
+    this.player.update(this.win ? 0 : this.gravity, this.groundY, delta);
     this.level.update(delta);
     if (this.gameOver && !this.player.dead && !this.win) {
       this.player.die();


### PR DESCRIPTION
## Summary
- Apply gravity after a loss so the princess falls instead of flying off-screen
- Add test ensuring gravity affects the player when the game is over

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68aabe017a7c832cbb9b569e11ca421e