### PR TITLE
Clamp canvas width for consistent gameplay

### DIFF
--- a/game.test.js
+++ b/game.test.js
@@ -2,7 +2,7 @@ import test from 'node:test';
 import assert from 'node:assert';
 import { createStubGame } from './testHelpers.js';
 import { Level2 } from './src/levels/level2.js';
-import { LEVEL_UP_SCORE } from './src/config.js';
+import { LEVEL_UP_SCORE, MAX_CANVAS_WIDTH } from './src/config.js';
 
 const FRAME = 1 / 60;
 
@@ -59,6 +59,11 @@ test('throttles resize events', async () => {
   await new Promise(r => setTimeout(r, 250));
   assert.strictEqual(calls, 1);
   game.destroy();
+});
+
+test('caps canvas width at maximum value', () => {
+  const game = createStubGame({ innerWidth: MAX_CANVAS_WIDTH + 500, skipLevelUpdate: true });
+  assert.strictEqual(game.canvas.width, MAX_CANVAS_WIDTH);
 });
 
 test('player continues to fall after losing', () => {

--- a/level2.test.js
+++ b/level2.test.js
@@ -2,6 +2,7 @@ import test from 'node:test';
 import assert from 'node:assert';
 import { createStubGame } from './testHelpers.js';
 import { Level2 } from './src/levels/level2.js';
+import { MAX_CANVAS_WIDTH } from './src/config.js';
 
 const FRAME = 1 / 60;
 
@@ -31,6 +32,13 @@ test('boss initial position uses resized canvas width', () => {
   const game = createStubGame({ canvasWidth: 300, innerWidth: 800, search: '?level=2', skipLevelUpdate: true });
   assert.strictEqual(game.canvas.width, 800);
   assert.strictEqual(game.level.boss.x, 700);
+});
+
+test('boss position clamps when screen is wider than maximum', () => {
+  const wide = MAX_CANVAS_WIDTH + 500;
+  const game = createStubGame({ canvasWidth: 300, innerWidth: wide, search: '?level=2', skipLevelUpdate: true });
+  assert.strictEqual(game.canvas.width, MAX_CANVAS_WIDTH);
+  assert.strictEqual(game.level.boss.x, MAX_CANVAS_WIDTH - 100);
 });
 
 test('shield deactivates even when input is spammed', () => {

--- a/src/config.js
+++ b/src/config.js
@@ -5,3 +5,5 @@ export const LEVEL_UP_SCORE = 1000;
 export const JUMP_VELOCITY = -720;
 // Delay between canvas resize adjustments (ms)
 export const RESIZE_THROTTLE_MS = 200;
+// Maximum width of the canvas to ensure consistent gameplay across devices
+export const MAX_CANVAS_WIDTH = 800;

--- a/src/game.js
+++ b/src/game.js
@@ -10,6 +10,7 @@ import {
   GRAVITY,
   LEVEL_UP_SCORE,
   RESIZE_THROTTLE_MS,
+  MAX_CANVAS_WIDTH,
 } from './config.js';
 
 export class Game {
@@ -74,7 +75,7 @@ export class Game {
   }
 
   resizeCanvas() {
-    this.canvas.width = window.innerWidth;
+    this.canvas.width = Math.min(window.innerWidth, MAX_CANVAS_WIDTH);
     // Ensure the canvas fits in the remaining viewport height so the
     // player is visible without scrolling, especially on mobile devices.
     let availableHeight = window.innerHeight || this.canvas.height;

--- a/style.css
+++ b/style.css
@@ -34,6 +34,7 @@ canvas {
   display: block;
   margin: 0 auto;
   width: 100%;
+  max-width: 800px;
 }
 
 #menu {


### PR DESCRIPTION
## Summary
- Limit canvas width to a maximum of 800px for consistent game difficulty
- Clamp Level 2 boss position based on the capped canvas width
- Add tests covering canvas width capping and boss placement

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68ab302ce6a8832cad8212173b18d5ac