### PR TITLE
Fix obstacle collision after clearing in level 1

### DIFF
--- a/earlyJump.test.js
+++ b/earlyJump.test.js
@@ -1,0 +1,22 @@
+import test from 'node:test';
+import assert from 'node:assert';
+import { createStubGame } from './testHelpers.js';
+
+const FRAME = 1 / 60;
+
+// Ensure that jumping early over an obstacle no longer causes a collision
+// once the obstacle has been cleared.
+test('player can jump early without landing on obstacle', () => {
+  const game = createStubGame();
+  const obstacle = game.level.createObstacle();
+  obstacle.x = 174; // far enough that player previously landed on it
+  obstacle.y = game.groundY;
+  game.level.obstacles = [obstacle];
+
+  game.player.jump();
+  for (let i = 0; i < 120; i++) {
+    game.update(FRAME);
+  }
+
+  assert.strictEqual(game.gameOver, false);
+});

--- a/src/levels/baseLevel.js
+++ b/src/levels/baseLevel.js
@@ -56,12 +56,12 @@ export class BaseLevel {
     const move = this.getMoveSpeed() * delta;
     this.obstacles.forEach(o => {
       o.update(move);
-      if (o.x + o.width < this.game.player.x) {
-        this.onObstaclePassed(o);
-      }
     });
     this.obstacles = this.obstacles.filter(o => {
-      if (o.x + o.width < 0) return false;
+      if (o.x + o.width < this.game.player.x + this.game.player.width) {
+        this.onObstaclePassed(o);
+        return false;
+      }
       return this.handleCollision(o);
     });
   }


### PR DESCRIPTION
## Summary
- remove obstacles once the player fully passes them to avoid unfair collisions
- add regression test verifying early jumps no longer cause game over

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ab63b58840832c9625c7de77d81261