### PR TITLE
Tune physics for larger sprites

### DIFF
--- a/coins.test.js
+++ b/coins.test.js
@@ -9,7 +9,7 @@ const FRAME = 1 / 60;
 
 test('awards coin for passed obstacle and preserves coins in level 2', () => {
   const game = createStubGame();
-  const obstacle = new Obstacle(game.player.x - 30, game.groundY, 40, 80);
+  const obstacle = new Obstacle(game.player.x - 50, game.groundY, 40, 80);
   obstacle.coinAwarded = false;
   game.level.obstacles.push(obstacle);
 

--- a/landing.test.js
+++ b/landing.test.js
@@ -1,15 +1,19 @@
 import test from 'node:test';
 import assert from 'node:assert';
 import { createStubGame } from './testHelpers.js';
+import { JUMP_VELOCITY, GRAVITY } from './src/config.js';
 
 const FRAME = 1 / 60;
 
-test('player lands within one second after jumping', () => {
+test('player lands within expected time after jumping', () => {
   const game = createStubGame({ skipLevelUpdate: true });
   const { player, groundY } = game;
 
+  const jumpDuration = (-2 * JUMP_VELOCITY) / GRAVITY;
+  const framesToLand = Math.ceil(jumpDuration / FRAME);
+
   player.jump();
-  for (let i = 0; i < 60; i++) {
+  for (let i = 0; i < framesToLand; i++) {
     game.update(FRAME);
   }
 

--- a/src/config.js
+++ b/src/config.js
@@ -2,6 +2,6 @@ export const GAME_SPEED = 180;
 // Slightly reduced gravity to give players more air time.
 export const GRAVITY = 1800;
 export const LEVEL_UP_SCORE = 1000;
-export const JUMP_VELOCITY = -720;
+export const JUMP_VELOCITY = -1020;
 // Delay between canvas resize adjustments (ms)
 export const RESIZE_THROTTLE_MS = 200;

--- a/src/levels/baseLevel.js
+++ b/src/levels/baseLevel.js
@@ -58,7 +58,7 @@ export class BaseLevel {
       o.update(move);
     });
     this.obstacles = this.obstacles.filter(o => {
-      if (o.x + o.width < this.game.player.x + this.game.player.width) {
+      if (o.x + o.width < this.game.player.x) {
         this.onObstaclePassed(o);
         return false;
       }


### PR DESCRIPTION
## Summary
- Increase jump velocity to match the new, larger character and obstacle sizes
- Fix obstacle removal logic so coins are awarded only after obstacles fully pass the player
- Adjust tests for updated jump duration and coin-award conditions

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68ab69041618832c84b0f09763b143fd