### PR TITLE
Increase tree speed and adjust spacing

### DIFF
--- a/src/levels/baseLevel.js
+++ b/src/levels/baseLevel.js
@@ -11,7 +11,8 @@ export class BaseLevel {
   }
 
   static getInterval(random) {
-    return (100 + random() * 80) / 60; // seconds
+    // Obstacles move faster, so shorten spawn intervals to keep spacing consistent.
+    return (75 + random() * 60) / 60; // seconds
   }
 
   createObstacle() {

--- a/src/levels/level1.js
+++ b/src/levels/level1.js
@@ -1,3 +1,8 @@
 import { BaseLevel } from './baseLevel.js';
 
-export class Level1 extends BaseLevel {}
+export class Level1 extends BaseLevel {
+  getMoveSpeed() {
+    // Increase tree velocity so the princess can pass them more easily.
+    return this.game.speed + 60;
+  }
+}


### PR DESCRIPTION
## Summary
- Speed up level 1 obstacles so the princess can overtake trees
- Shorten obstacle spawn intervals to keep tree spacing balanced

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68ab6cc86a64832c813339928083e1aa