### PR TITLE
Expand shield range in level 2

### DIFF
--- a/level2.test.js
+++ b/level2.test.js
@@ -53,3 +53,19 @@ test('shield can be reactivated after cooldown', () => {
   game.handleInput();
   assert.strictEqual(player.shieldActive, true);
 });
+
+test('shield blocks obstacles slightly earlier', () => {
+  const game = createStubGame({ search: '?level=2', skipLevelUpdate: true });
+  const level = game.level;
+  const player = game.player;
+  const wall = level.createObstacle();
+  const gap = 5;
+  wall.x = player.x + player.width + gap;
+
+  // Without shield the obstacle should pass
+  assert.ok(level.handleCollision(wall));
+
+  // With shield active it should collide
+  player.activateShield();
+  assert.ok(!level.handleCollision(wall));
+});

--- a/src/config.js
+++ b/src/config.js
@@ -5,3 +5,5 @@ export const LEVEL_UP_SCORE = 1000;
 export const JUMP_VELOCITY = -1200;
 // Delay between canvas resize adjustments (ms)
 export const RESIZE_THROTTLE_MS = 200;
+// Extra reach for the level 2 shield in pixels (before scaling)
+export const SHIELD_RANGE = 10;

--- a/src/levels/level2.js
+++ b/src/levels/level2.js
@@ -1,6 +1,7 @@
 import { BaseLevel } from './baseLevel.js';
 import { Obstacle } from '../obstacle.js';
 import { isColliding } from '../../collision.js';
+import { SHIELD_RANGE } from '../config.js';
 
 export class Level2 extends BaseLevel {
   constructor(game, random = Math.random) {
@@ -43,14 +44,20 @@ export class Level2 extends BaseLevel {
   onObstaclePassed() {}
 
   handleCollision(w) {
-    if (isColliding(this.game.player, w)) {
-      if (this.game.player.shieldActive) {
-        this.game.player.x += 20;
+    const player = this.game.player;
+    const range = player.shieldActive ? SHIELD_RANGE * this.game.scale : 0;
+    const collider = player.shieldActive
+      ? { x: player.x - range, y: player.y, width: player.width + range * 2, height: player.height }
+      : player;
+
+    if (isColliding(collider, w)) {
+      if (player.shieldActive) {
+        player.x += 20;
         this.coins.push({
           x: w.x + w.width / 2,
           y: w.y - w.height / 2,
           vy: -120,
-          life: 0.5
+          life: 0.5,
         });
         this.game.coins++;
         return false;

--- a/src/renderer.js
+++ b/src/renderer.js
@@ -1,4 +1,5 @@
 import { AssetManager } from './assetManager.js';
+import { SHIELD_RANGE } from './config.js';
 
 export class Renderer {
   constructor(game) {
@@ -116,10 +117,11 @@ export class Renderer {
         ctx.fill();
       }
       if (u.shieldActive) {
+        const extra = SHIELD_RANGE * this.game.scale * 2;
         if (this.shieldSprite) {
           const img = this.shieldSprite;
-          const w = img.width || u.width;
-          const h = img.height || u.height;
+          const w = (img.width || u.width) + extra;
+          const h = (img.height || u.height) + extra;
           const sx = u.x + u.width / 2 - w / 2;
           const sy = u.y - u.height / 2 - h / 2;
           ctx.drawImage(img, sx, sy, w, h);
@@ -127,7 +129,13 @@ export class Renderer {
           ctx.strokeStyle = 'blue';
           ctx.lineWidth = 3;
           ctx.beginPath();
-          ctx.arc(u.x + u.width / 2, u.y - u.height / 2, u.width, 0, Math.PI * 2);
+          ctx.arc(
+            u.x + u.width / 2,
+            u.y - u.height / 2,
+            u.width + SHIELD_RANGE * this.game.scale,
+            0,
+            Math.PI * 2,
+          );
           ctx.stroke();
         }
       }


### PR DESCRIPTION
## Summary
- extend level 2 shield collider with configurable range
- scale shield sprite to match larger collision area
- verify shield blocks walls before direct contact

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68ab72775ea8832c999668fd95eb3dfb