### PR TITLE
Clamp player jump to stay onscreen

### DIFF
--- a/earlyJump.test.js
+++ b/earlyJump.test.js
@@ -7,7 +7,7 @@ const FRAME = 1 / 60;
 // Ensure that jumping early over an obstacle no longer causes a collision
 // once the obstacle has been cleared.
 test('player can jump early without landing on obstacle', () => {
-  const game = createStubGame();
+  const game = createStubGame({ canvasHeight: 600, innerHeight: 600 });
   const obstacle = game.level.createObstacle();
   obstacle.x = 174; // far enough that player previously landed on it
   obstacle.y = game.groundY;

--- a/screenBounds.test.js
+++ b/screenBounds.test.js
@@ -1,0 +1,17 @@
+import test from 'node:test';
+import assert from 'node:assert';
+import { createStubGame } from './testHelpers.js';
+
+const FRAME = 1 / 60;
+
+test('player remains within vertical bounds when jumping', () => {
+  const game = createStubGame({ skipLevelUpdate: true });
+  const { player } = game;
+  player.jump();
+  let minY = Infinity;
+  for (let i = 0; i < 120; i++) {
+    game.update(FRAME);
+    if (player.y < minY) minY = player.y;
+  }
+  assert.ok(minY >= player.height);
+});

--- a/src/player.js
+++ b/src/player.js
@@ -23,6 +23,10 @@ export class Player {
   update(gravity, groundY, delta) {
     this.vy += gravity * delta;
     this.y += this.vy * delta;
+    if (this.y - this.height < 0) {
+      this.y = this.height;
+      if (this.vy < 0) this.vy = 0;
+    }
     if (this.y >= groundY) {
       this.y = groundY;
       this.vy = 0;

--- a/testHelpers.js
+++ b/testHelpers.js
@@ -3,7 +3,9 @@ import { Game } from './src/game.js';
 export function createStubGame({
   rng,
   canvasWidth = 800,
+  canvasHeight = 200,
   innerWidth = 800,
+  innerHeight = canvasHeight,
   search = '',
   skipLevelUpdate = false,
 } = {}) {
@@ -20,7 +22,7 @@ export function createStubGame({
     fillText: noop,
     measureText: () => ({ width: 0 }),
   };
-  const canvas = { width: canvasWidth, height: 200, getContext: () => ctx };
+  const canvas = { width: canvasWidth, height: canvasHeight, getContext: () => ctx };
   const overlay = { classList: { add: noop, remove: noop } };
   const overlayContent = { textContent: '' };
   const overlayButton = { onclick: null, textContent: '', addEventListener: noop };
@@ -46,6 +48,7 @@ export function createStubGame({
   const eventListeners = {};
   global.window = {
     innerWidth,
+    innerHeight,
     location: { search },
     addEventListener: (event, handler) => {
       eventListeners[event] = handler;


### PR DESCRIPTION
## Summary
- prevent the player from jumping above the visible area by clamping vertical position
- allow test stubs to specify canvas and window height for accurate physics
- cover jump visibility with dedicated test and update early jump scenario

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68ab729920d4832cab81832cccbacd43