### PR TITLE
Adjust princess jump height and field height

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -1,8 +1,10 @@
 export const GAME_SPEED = 180;
-// Slightly reduced gravity to give players more air time.
-export const GRAVITY = 1800;
+// Adjusted physics to lower the princess's jump height while maintaining
+// her jump distance.
+export const GRAVITY = 1350;
 export const LEVEL_UP_SCORE = 1000;
-export const JUMP_VELOCITY = -1200;
+// Reduced from -1200 so the princess doesn't jump as high.
+export const JUMP_VELOCITY = -900;
 // Delay between canvas resize adjustments (ms)
 export const RESIZE_THROTTLE_MS = 200;
 // Extra reach for the level 2 shield in pixels (before scaling)

--- a/src/game.js
+++ b/src/game.js
@@ -84,7 +84,7 @@ export class Game {
     // height, expand the canvas instead of letting the character leave the
     // field of view.
     const availableHeight = window.innerHeight || this.canvas.height;
-    const minHeight = 640; // jump arc (~400) + max player height (~160) + ground
+    const minHeight = 480; // jump arc (~300) + max player height (~160) + ground
     this.canvas.height = Math.max(availableHeight, minHeight);
     this.groundY = this.canvas.height - 50;
     const widthScale = window.innerWidth / 800;


### PR DESCRIPTION
## Summary
- Lower princess jump height by reducing gravity and jump velocity
- Shrink minimum game field height to match shorter jumps

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ab80f05664832ca418e22bbd79d0bb