### PR TITLE
Tweak jump height

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -1,10 +1,9 @@
 export const GAME_SPEED = 180;
-// Adjusted physics to lower the princess's jump height while maintaining
-// her jump distance.
+// Lower the jump height while keeping the fall speed the same.
 export const GRAVITY = 1350;
 export const LEVEL_UP_SCORE = 1000;
-// Reduced from -1200 so the princess doesn't jump as high.
-export const JUMP_VELOCITY = -900;
+// Further reduce the upward launch velocity so jumps clear obstacles with a small margin.
+export const JUMP_VELOCITY = -620;
 // Delay between canvas resize adjustments (ms)
 export const RESIZE_THROTTLE_MS = 200;
 // Extra reach for the level 2 shield in pixels (before scaling)


### PR DESCRIPTION
## Summary
- lower jump velocity so the princess only leaps high enough to clear obstacles while keeping fall speed unchanged

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68abee7097e4832caccc9dddfa445915