### PR TITLE
Add viewport scaling for consistent world size

### DIFF
--- a/main.js
+++ b/main.js
@@ -1,9 +1,12 @@
 import { Game } from './src/game.js';
 import { LEVEL_UP_SCORE } from './src/config.js';
 import { Overlay } from './src/overlay.js';
+import { attachViewport } from './src/render/viewport.js';
 
 window.addEventListener('DOMContentLoaded', () => {
   const canvas = document.getElementById('game');
+  const viewport = attachViewport(canvas);
+  // usa viewport.getView(), worldToScreen, screenToWorld
   const menu = document.getElementById('menu');
   const playButton = document.getElementById('play-button');
   const instructionsButton = document.getElementById('instructions-button');

--- a/src/config/world.js
+++ b/src/config/world.js
@@ -1,0 +1,2 @@
+export const WORLD_WIDTH = 16;
+export const WORLD_HEIGHT = 9;

--- a/src/render/viewport.js
+++ b/src/render/viewport.js
@@ -1,0 +1,24 @@
+import { WORLD_WIDTH, WORLD_HEIGHT } from '../config/world.js';
+
+export function attachViewport(canvas) {
+  function resize() {
+    const w = window.innerWidth;
+    const h = window.innerHeight;
+    const scale = Math.min(w / WORLD_WIDTH, h / WORLD_HEIGHT);
+    canvas.width  = Math.round(WORLD_WIDTH  * scale);
+    canvas.height = Math.round(WORLD_HEIGHT * scale);
+    const offX = Math.floor((w - canvas.width) / 2);
+    const offY = Math.floor((h - canvas.height) / 2);
+    canvas.style.position = 'absolute';
+    canvas.style.left = offX + 'px';
+    canvas.style.top  = offY + 'px';
+    return { scale, offX, offY };
+  }
+  let view = resize();
+  window.addEventListener('resize', () => { view = resize(); });
+  return {
+    getView(){ return view; },
+    worldToScreen(x, y){ return { sx: x * view.scale, sy: y * view.scale }; },
+    screenToWorld(px, py){ return { x: px / view.scale, y: py / view.scale }; }
+  };
+}


### PR DESCRIPTION
## Summary
- Define WORLD_WIDTH and WORLD_HEIGHT constants for the fixed world dimensions
- Implement viewport attachment that scales the canvas and converts between world and screen coordinates
- Initialize viewport in main entry to maintain consistent view across devices

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68abf072dda4832cab4ffa48271e8911