### PR TITLE
Add fixed timestep game loop and physics config

### DIFF
--- a/src/config/physics.js
+++ b/src/config/physics.js
@@ -1,0 +1,2 @@
+export const FIXED_DT = 1/60;
+export const GRAVITY = 30;

--- a/src/core/loop.js
+++ b/src/core/loop.js
@@ -1,0 +1,19 @@
+import { FIXED_DT } from '../config/physics.js';
+
+export function startGameLoop({ step, render }) {
+  let last = performance.now();
+  let acc = 0;
+
+  function frame(now) {
+    acc += (now - last) / 1000;
+    last = now;
+
+    while (acc >= FIXED_DT) {
+      step(FIXED_DT);
+      acc -= FIXED_DT;
+    }
+    render();
+    requestAnimationFrame(frame);
+  }
+  requestAnimationFrame(frame);
+}

--- a/src/main.js
+++ b/src/main.js
@@ -1,0 +1,9 @@
+import { startGameLoop } from './core/loop.js';
+
+function step(dt){
+  // logica fisica (movimenti, gravità, spawn, collisioni)
+}
+function render(){
+  // disegno
+}
+startGameLoop({ step, render });


### PR DESCRIPTION
## Summary
- define physics constants including FIXED_DT and GRAVITY
- add a fixed-delta game loop to separate physics updates from rendering
- wire up a simple main entry to start the loop

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68abf12673fc832ca6ead2bd735e98f4