### PR TITLE
feat: add unit-based player with jump physics

### DIFF
--- a/src/entities/player.js
+++ b/src/entities/player.js
@@ -1,0 +1,32 @@
+import { GRAVITY } from '../config/physics.js';
+
+export class Player {
+  constructor({ x=2, y=0, width=0.6, height=1.0 }) {
+    this.x = x; this.y = y;
+    this.w = width; this.h = height;
+    this.vx = 0; this.vy = 0;
+    this.onGround = true;
+    this.jumpVelocity = Math.sqrt(2 * GRAVITY * 1.2);
+  }
+
+  setJumpHeight(h){
+    this.jumpVelocity = Math.sqrt(2 * GRAVITY * h);
+  }
+
+  jump(){
+    if (this.onGround) {
+      this.vy = -this.jumpVelocity;
+      this.onGround = false;
+    }
+  }
+
+  step(dt, groundY=0){
+    this.vy += GRAVITY * dt;
+    this.y  += this.vy * dt;
+    if (this.y + this.h >= groundY) {
+      this.y = groundY - this.h;
+      this.vy = 0;
+      this.onGround = true;
+    }
+  }
+}

--- a/src/main.js
+++ b/src/main.js
@@ -1,9 +1,17 @@
 import { startGameLoop } from './core/loop.js';
+import { Player } from './entities/player.js';
+
+const groundY = 0;
+const player = new Player({ x: 2, y: 0, width: 0.6, height: 1.0 });
+// player.setJumpHeight(3.0);
 
 function step(dt){
+  player.step(dt, groundY);
   // logica fisica (movimenti, gravità, spawn, collisioni)
 }
+
 function render(){
   // disegno
 }
+
 startGameLoop({ step, render });


### PR DESCRIPTION
## Summary
- introduce world-unit Player entity with independent hitbox and jump height control
- wire Player into main loop using world-unit dimensions

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68abf1e8dbb8832cb062a06b4eddc5ae