### PR TITLE
Add timed obstacle spawner with initial delay

### DIFF
--- a/src/config/spawn.js
+++ b/src/config/spawn.js
@@ -1,0 +1,3 @@
+export const SPAWN_EVERY_S = 1.6;
+export const FIRST_SPAWN_DELAY_S = 2.5;
+export const WORLD_SPEED = 7;

--- a/src/systems/spawn.js
+++ b/src/systems/spawn.js
@@ -1,0 +1,21 @@
+import { SPAWN_EVERY_S, FIRST_SPAWN_DELAY_S, WORLD_SPEED } from '../config/spawn.js';
+
+export class Spawner {
+  constructor(world) {
+    this.world = world;
+    this.timer = -FIRST_SPAWN_DELAY_S;
+  }
+  update(dt) {
+    this.timer += dt;
+    while (this.timer >= SPAWN_EVERY_S) {
+      this.timer -= SPAWN_EVERY_S;
+      this.world.spawnObstacle({
+        x: this.world.cameraRight + 2,
+        y: 0,
+        w: 1,
+        h: 1,
+        vx: -WORLD_SPEED
+      });
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- Define spawn timing and world speed constants
- Implement spawner system to spawn obstacles at fixed intervals and speed

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68abf2b38200832cae824e1b9e82ac3f