### PR TITLE
Add shield cooldown indicator to UI

### DIFF
--- a/level2.test.js
+++ b/level2.test.js
@@ -69,3 +69,11 @@ test('shield blocks obstacles slightly earlier', () => {
   player.activateShield();
   assert.ok(!level.handleCollision(wall));
 });
+
+test('shield cooldown bar uses latest cooldown value', () => {
+  const game = createStubGame({ search: '?level=2', skipLevelUpdate: true });
+  const player = game.player;
+  assert.strictEqual(player.shieldCooldownMax, 1);
+  player.activateShield(0.25, 2);
+  assert.strictEqual(player.shieldCooldownMax, 2);
+});

--- a/src/player.js
+++ b/src/player.js
@@ -12,6 +12,7 @@ export class Player {
     this.shieldActive = false;
     this.shieldTimer = 0;
     this.shieldCooldown = 0;
+    this.shieldCooldownMax = 1;
     this.dead = false;
   }
 
@@ -50,6 +51,7 @@ export class Player {
       this.shieldActive = true;
       this.shieldTimer = duration;
       this.shieldCooldown = cooldown;
+      this.shieldCooldownMax = cooldown;
     }
   }
 

--- a/src/renderer.js
+++ b/src/renderer.js
@@ -220,6 +220,28 @@ export class Renderer {
       ctx.fillText(`x ${game.coins}`, coinX - 10, 20);
       ctx.textAlign = 'left';
 
+      const p = game.player;
+      const iconSize = 16;
+      if (this.shieldSprite) {
+        ctx.drawImage(this.shieldSprite, 10, 28, iconSize, iconSize);
+      } else {
+        ctx.strokeStyle = 'blue';
+        ctx.beginPath();
+        ctx.arc(18, 36, 8, 0, Math.PI * 2);
+        ctx.stroke();
+      }
+      const barX = 10 + iconSize + 5;
+      const barY = 30;
+      const barWidth = 80;
+      const barHeight = 10;
+      ctx.strokeStyle = '#000';
+      ctx.strokeRect(barX, barY, barWidth, barHeight);
+      const progress = p.shieldCooldownMax
+        ? (p.shieldCooldownMax - p.shieldCooldown) / p.shieldCooldownMax
+        : 1;
+      ctx.fillStyle = 'rgba(0, 0, 255, 0.5)';
+      ctx.fillRect(barX, barY, barWidth * progress, barHeight);
+
       if (game.gameOver) {
         ctx.fillStyle = '#000';
         ctx.font = '24px sans-serif';


### PR DESCRIPTION
## Summary
- Track max shield cooldown in Player to support progress display
- Display shield icon and cooldown bar in renderer UI
- Add test ensuring cooldown max updates

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68abf77304f8832c901d86f3a31f162b