### PR TITLE
Add CI workflow and obstacle spawn test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,15 @@
+name: CI
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+      - run: npm test

--- a/obstacleSpawn.test.js
+++ b/obstacleSpawn.test.js
@@ -1,0 +1,14 @@
+import test from 'node:test';
+import assert from 'node:assert';
+import { createStubGame } from './testHelpers.js';
+
+const FRAME = 1 / 60;
+
+test('spawns a new obstacle after interval', () => {
+  const game = createStubGame();
+  const level = game.level;
+  assert.strictEqual(level.obstacles.length, 0);
+  level.timer = level.interval;
+  level.update(FRAME);
+  assert.strictEqual(level.obstacles.length, 1);
+});


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow to run tests on push and PR
- cover obstacle spawning with a new test

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ac0060e29c832c9f55d81528952f9f