### PR TITLE
Speed up shield recharge

### DIFF
--- a/level2.test.js
+++ b/level2.test.js
@@ -2,6 +2,7 @@ import test from 'node:test';
 import assert from 'node:assert';
 import { createStubGame } from './testHelpers.js';
 import { Level2 } from './src/levels/level2.js';
+import { SHIELD_COOLDOWN } from './src/config.js';
 
 const FRAME = 1 / 60;
 
@@ -47,7 +48,8 @@ test('shield can be reactivated after cooldown', () => {
   const game = createStubGame({ search: '?level=2', skipLevelUpdate: true });
   const player = game.player;
   game.handleInput();
-  for (let i = 0; i < 60; i++) {
+  const frames = Math.ceil(SHIELD_COOLDOWN / FRAME);
+  for (let i = 0; i <= frames; i++) {
     player.update(0, game.groundY, FRAME);
   }
   game.handleInput();
@@ -73,7 +75,7 @@ test('shield blocks obstacles slightly earlier', () => {
 test('shield cooldown bar uses latest cooldown value', () => {
   const game = createStubGame({ search: '?level=2', skipLevelUpdate: true });
   const player = game.player;
-  assert.strictEqual(player.shieldCooldownMax, 1);
+  assert.strictEqual(player.shieldCooldownMax, SHIELD_COOLDOWN);
   player.activateShield(0.25, 2);
   assert.strictEqual(player.shieldCooldownMax, 2);
 });

--- a/src/config.js
+++ b/src/config.js
@@ -8,3 +8,5 @@ export const JUMP_VELOCITY = -620;
 export const RESIZE_THROTTLE_MS = 200;
 // Extra reach for the level 2 shield in pixels (before scaling)
 export const SHIELD_RANGE = 10;
+// Default shield cooldown duration in seconds
+export const SHIELD_COOLDOWN = 0.5;

--- a/src/player.js
+++ b/src/player.js
@@ -1,4 +1,4 @@
-import { JUMP_VELOCITY } from './config.js';
+import { JUMP_VELOCITY, SHIELD_COOLDOWN } from './config.js';
 
 export class Player {
   constructor(x, groundY, scale = 1) {
@@ -12,7 +12,7 @@ export class Player {
     this.shieldActive = false;
     this.shieldTimer = 0;
     this.shieldCooldown = 0;
-    this.shieldCooldownMax = 1;
+    this.shieldCooldownMax = SHIELD_COOLDOWN;
     this.dead = false;
   }
 
@@ -46,7 +46,7 @@ export class Player {
     }
   }
 
-  activateShield(duration = 0.25, cooldown = 1) {
+  activateShield(duration = 0.25, cooldown = SHIELD_COOLDOWN) {
     if (!this.shieldActive && this.shieldCooldown === 0) {
       this.shieldActive = true;
       this.shieldTimer = duration;


### PR DESCRIPTION
## Summary
- Define `SHIELD_COOLDOWN` to default shield recharge to half a second
- Use new constant in `Player` so shields become available sooner
- Update tests to account for faster shield cooldown

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ac00205e90832cbe0ae7e00ef2504c