### PR TITLE
Implement fixed timestep physics and decouple sprite scaling

### DIFF
--- a/fixedTimestep.test.js
+++ b/fixedTimestep.test.js
@@ -1,0 +1,21 @@
+import test from 'node:test';
+import assert from 'node:assert';
+import { createStubGame } from './testHelpers.js';
+
+const STEP = 1 / 60;
+
+// Verify that the main game loop advances the simulation using a fixed 60 Hz
+// timestep regardless of the frame delta provided.
+test('game loop uses fixed 60 Hz timestep', () => {
+  const game = createStubGame({ skipLevelUpdate: true });
+  const deltas = [];
+  game.update = d => deltas.push(d);
+  game.draw = () => {};
+
+  // Prime the loop.
+  game.loop(0);
+  // Simulate a frame arriving with double the timestep (1/30s)
+  game.loop(1000 / 30);
+
+  assert.deepStrictEqual(deltas, [STEP, STEP]);
+});

--- a/jumpScale.test.js
+++ b/jumpScale.test.js
@@ -1,0 +1,27 @@
+import test from 'node:test';
+import assert from 'node:assert';
+import { createStubGame } from './testHelpers.js';
+import { JUMP_VELOCITY, GRAVITY } from './src/config.js';
+
+const FRAME = 1 / 60;
+
+function simulate(innerWidth) {
+  const game = createStubGame({ innerWidth, skipLevelUpdate: true });
+  const { player, groundY } = game;
+  const jumpDuration = (-2 * JUMP_VELOCITY) / GRAVITY;
+  const framesToLand = Math.ceil(jumpDuration / FRAME);
+  player.jump();
+  let minY = groundY;
+  for (let i = 0; i < framesToLand; i++) {
+    game.update(FRAME);
+    if (player.y < minY) minY = player.y;
+  }
+  return { finalY: player.y, minY };
+}
+
+test('jump height and timing unaffected by sprite scale', () => {
+  const normal = simulate(800); // scale ~1
+  const scaled = simulate(1600); // scale ~2
+  assert.ok(Math.abs(normal.finalY - scaled.finalY) < 1e-6);
+  assert.ok(Math.abs(normal.minY - scaled.minY) < 1e-6);
+});

--- a/src/levels/level2.js
+++ b/src/levels/level2.js
@@ -10,11 +10,10 @@ export class Level2 extends BaseLevel {
     this.boss = {
       x: game.canvas.width - 100,
       y: game.groundY,
-      baseWidth: 80,
-      baseHeight: 100,
+      width: 80,
+      height: 100,
+      spriteScale: game.scale,
     };
-    this.boss.width = this.boss.baseWidth * game.scale;
-    this.boss.height = this.boss.baseHeight * game.scale;
     this.bossFlee = false;
     this.coins = [];
     this.initialDistance =
@@ -45,7 +44,10 @@ export class Level2 extends BaseLevel {
 
   handleCollision(w) {
     const player = this.game.player;
-    const range = player.shieldActive ? SHIELD_RANGE * this.game.scale : 0;
+    // Shield range is defined in world units and should not scale with the
+    // sprite size so that collisions remain consistent regardless of
+    // rendering scale.
+    const range = player.shieldActive ? SHIELD_RANGE : 0;
     const collider = player.shieldActive
       ? { x: player.x - range, y: player.y, width: player.width + range * 2, height: player.height }
       : player;
@@ -101,7 +103,6 @@ export class Level2 extends BaseLevel {
 
   setScale(scale) {
     super.setScale(scale);
-    this.boss.width = this.boss.baseWidth * scale;
-    this.boss.height = this.boss.baseHeight * scale;
+    this.boss.spriteScale = scale;
   }
 }

--- a/src/obstacle.js
+++ b/src/obstacle.js
@@ -2,14 +2,18 @@ export class Obstacle {
   constructor(x, y, width, height) {
     this.x = x;
     this.y = y; // bottom position
+    // Store both the physical hitbox size (width/height) and the scale used
+    // only for rendering. The hitbox stays in world units regardless of the
+    // sprite size.
+    this.width = width;
+    this.height = height;
     this.baseWidth = width;
     this.baseHeight = height;
-    this.setScale(1);
+    this.spriteScale = 1;
   }
 
   setScale(scale) {
-    this.width = this.baseWidth * scale;
-    this.height = this.baseHeight * scale;
+    this.spriteScale = scale;
   }
 
   update(speed) {

--- a/src/player.js
+++ b/src/player.js
@@ -6,7 +6,11 @@ export class Player {
     this.y = groundY; // bottom position
     this.baseWidth = 80;
     this.baseHeight = 80;
-    this.setScale(scale);
+    // Physical hitbox dimensions remain in world units, independent of the
+    // sprite scale used for rendering.
+    this.width = this.baseWidth;
+    this.height = this.baseHeight;
+    this.spriteScale = scale;
     this.vy = 0;
     this.jumping = false;
     this.shieldActive = false;
@@ -17,8 +21,7 @@ export class Player {
   }
 
   setScale(scale) {
-    this.width = this.baseWidth * scale;
-    this.height = this.baseHeight * scale;
+    this.spriteScale = scale;
   }
 
   update(gravity, groundY, delta) {

--- a/src/renderer.js
+++ b/src/renderer.js
@@ -85,6 +85,9 @@ export class Renderer {
   drawPlayer() {
     const u = this.game.player;
     this.withContext(ctx => {
+      const scaledWidth = u.width * u.spriteScale;
+      const scaledHeight = u.height * u.spriteScale;
+
       if (this.playerSprites) {
         const now = typeof performance !== 'undefined' ? performance.now() : Date.now();
         if (!this.lastSpriteTime) this.lastSpriteTime = now;
@@ -98,41 +101,41 @@ export class Renderer {
           this.playerFrameIndex = (this.playerFrameIndex + 1) % frames.length;
         }
         const img = frames[this.playerFrameIndex];
-        ctx.drawImage(img, u.x, u.y - u.height, u.width, u.height);
+        ctx.drawImage(img, u.x, u.y - scaledHeight, scaledWidth, scaledHeight);
       } else {
         ctx.fillStyle = '#fff';
-        ctx.fillRect(u.x, u.y - u.height, u.width, u.height);
-        ctx.fillRect(u.x + u.width - 10, u.y - u.height - 10, 10, 10);
+        ctx.fillRect(u.x, u.y - scaledHeight, scaledWidth, scaledHeight);
+        ctx.fillRect(u.x + scaledWidth - 10, u.y - scaledHeight - 10, 10, 10);
         ctx.fillStyle = 'gold';
         ctx.beginPath();
-        ctx.moveTo(u.x + u.width, u.y - u.height - 10);
-        ctx.lineTo(u.x + u.width + 10, u.y - u.height - 30);
-        ctx.lineTo(u.x + u.width, u.y - u.height - 20);
+        ctx.moveTo(u.x + scaledWidth, u.y - scaledHeight - 10);
+        ctx.lineTo(u.x + scaledWidth + 10, u.y - scaledHeight - 30);
+        ctx.lineTo(u.x + scaledWidth, u.y - scaledHeight - 20);
         ctx.fill();
         ctx.fillStyle = 'pink';
-        ctx.fillRect(u.x + 5, u.y - u.height - 25, 15, 15);
+        ctx.fillRect(u.x + 5, u.y - scaledHeight - 25, 15, 15);
         ctx.fillStyle = '#f2d6cb';
         ctx.beginPath();
-        ctx.arc(u.x + 12.5, u.y - u.height - 30, 7, 0, Math.PI * 2);
+        ctx.arc(u.x + 12.5, u.y - scaledHeight - 30, 7, 0, Math.PI * 2);
         ctx.fill();
       }
       if (u.shieldActive) {
-        const extra = SHIELD_RANGE * this.game.scale * 2;
+        const extra = SHIELD_RANGE * u.spriteScale;
         if (this.shieldSprite) {
           const img = this.shieldSprite;
-          const w = (img.width || u.width) + extra;
-          const h = (img.height || u.height) + extra;
-          const sx = u.x + u.width / 2 - w / 2;
-          const sy = u.y - u.height / 2 - h / 2;
+          const w = (img.width || scaledWidth) + extra * 2;
+          const h = (img.height || scaledHeight) + extra * 2;
+          const sx = u.x + scaledWidth / 2 - w / 2;
+          const sy = u.y - scaledHeight / 2 - h / 2;
           ctx.drawImage(img, sx, sy, w, h);
         } else {
           ctx.strokeStyle = 'blue';
           ctx.lineWidth = 3;
           ctx.beginPath();
           ctx.arc(
-            u.x + u.width / 2,
-            u.y - u.height / 2,
-            u.width + SHIELD_RANGE * this.game.scale,
+            u.x + scaledWidth / 2,
+            u.y - scaledHeight / 2,
+            scaledWidth + extra,
             0,
             Math.PI * 2,
           );
@@ -146,12 +149,14 @@ export class Renderer {
     const { game } = this;
     this.withContext(ctx => {
       game.level.obstacles.forEach(o => {
+        const w = o.width * o.spriteScale;
+        const h = o.height * o.spriteScale;
         if (this.treeSprites) {
           const img = this.treeSprites[(o.imageIndex ?? 0) % this.treeSprites.length];
-          ctx.drawImage(img, o.x, o.y - o.height, o.width, o.height);
+          ctx.drawImage(img, o.x, o.y - h, w, h);
         } else {
           ctx.fillStyle = 'green';
-          ctx.fillRect(o.x, o.y - o.height, o.width, o.height);
+          ctx.fillRect(o.x, o.y - h, w, h);
         }
       });
     });
@@ -162,15 +167,21 @@ export class Renderer {
     this.withContext(ctx => {
       if (this.wallSprite) {
         game.level.walls.forEach(w => {
-          ctx.drawImage(this.wallSprite, w.x, w.y - w.height, w.width, w.height);
+          const wWidth = w.width * w.spriteScale;
+          const wHeight = w.height * w.spriteScale;
+          ctx.drawImage(this.wallSprite, w.x, w.y - wHeight, wWidth, wHeight);
         });
       } else {
         ctx.fillStyle = 'gray';
         game.level.walls.forEach(w => {
-          ctx.fillRect(w.x, w.y - w.height, w.width, w.height);
+          const wWidth = w.width * w.spriteScale;
+          const wHeight = w.height * w.spriteScale;
+          ctx.fillRect(w.x, w.y - wHeight, wWidth, wHeight);
         });
       }
       const b = game.level.boss;
+      const bw = b.width * (b.spriteScale || 1);
+      const bh = b.height * (b.spriteScale || 1);
       if (this.knightSprites) {
         const now = typeof performance !== 'undefined' ? performance.now() : Date.now();
         if (!this.lastKnightTime) this.lastKnightTime = now;
@@ -182,10 +193,10 @@ export class Renderer {
           this.knightFrameIndex = (this.knightFrameIndex + 1) % this.knightSprites.length;
         }
         const img = this.knightSprites[this.knightFrameIndex];
-        ctx.drawImage(img, b.x, b.y - b.height, b.width, b.height);
+        ctx.drawImage(img, b.x, b.y - bh, bw, bh);
       } else {
         ctx.fillStyle = 'black';
-        ctx.fillRect(b.x, b.y - b.height, b.width, b.height);
+        ctx.fillRect(b.x, b.y - bh, bw, bh);
       }
     });
   }


### PR DESCRIPTION
## Summary
- Run game updates on a fixed 60 Hz timestep for consistent physics
- Keep player, obstacle, and boss hitboxes in world units while scaling only sprites
- Adjust shield and rendering logic to respect sprite scale without affecting collisions
- Add regression tests for fixed timestep loop and jump invariance to sprite scaling

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ac01a075d8832cbb73378166910e5b