### PR TITLE
Refactor collision detection to use centered hitboxes

### DIFF
--- a/collision.js
+++ b/collision.js
@@ -1,18 +1,16 @@
+// Axis-aligned bounding box collision detection using hitboxes centered on the
+// entities' logical coordinates. The `x`/`y` values supplied by the caller are
+// treated as the bottom-left corner in world units, so we convert them to
+// centre-based values before performing the overlap test. This keeps collision
+// results consistent regardless of how sprites are scaled for rendering.
 export function isColliding(a, b) {
-  const aLeft = a.x;
-  const aRight = a.x + a.width;
-  const aTop = a.y - a.height;
-  const aBottom = a.y;
-
-  const bLeft = b.x;
-  const bRight = b.x + b.width;
-  const bTop = b.y - b.height;
-  const bBottom = b.y;
+  const ax = a.x + a.width / 2;
+  const ay = a.y - a.height / 2;
+  const bx = b.x + b.width / 2;
+  const by = b.y - b.height / 2;
 
   return (
-    aLeft < bRight &&
-    aRight > bLeft &&
-    aBottom > bTop &&
-    aTop < bBottom
+    Math.abs(ax - bx) * 2 < a.width + b.width &&
+    Math.abs(ay - by) * 2 < a.height + b.height
   );
 }

--- a/collision.test.js
+++ b/collision.test.js
@@ -1,6 +1,7 @@
 import test from 'node:test';
 import assert from 'node:assert';
 import { isColliding } from './collision.js';
+import { Obstacle } from './src/obstacle.js';
 
 const groundY = 150;
 
@@ -37,4 +38,13 @@ test('detects collision while jumping into obstacle', () => {
   const unicorn = createEntity(50, groundY - 30, 80, 80); // mid-air
   const obstacle = createEntity(60, groundY, 40, 60);
   assert.strictEqual(isColliding(unicorn, obstacle), true);
+});
+
+test('sprite scaling does not affect collision result', () => {
+  const unicorn = createEntity(50, groundY, 80, 80);
+  const obstacle = new Obstacle(60, groundY, 40, 80);
+  const before = isColliding(unicorn, obstacle);
+  obstacle.setScale(2); // scale only affects rendering
+  const after = isColliding(unicorn, obstacle);
+  assert.strictEqual(before, after);
 });


### PR DESCRIPTION
## Summary
- compute AABB collisions using center-based hitboxes to keep logic independent of sprite size
- add regression test ensuring sprite scaling does not alter collision results

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_68ac039785c4832cbe695f34eeabb76f