### PR TITLE
Guard custom element registration to avoid duplicate definition errors

### DIFF
--- a/custom-elements-patch.js
+++ b/custom-elements-patch.js
@@ -1,0 +1,12 @@
+/**
+ * Patch customElements.define to ignore re-definitions.
+ * This avoids errors when the same Custom Element is registered more than once.
+ */
+if (window.customElements) {
+  const origDefine = window.customElements.define.bind(window.customElements);
+  window.customElements.define = function(name, constructor, options) {
+    if (!window.customElements.get(name)) {
+      origDefine(name, constructor, options);
+    }
+  };
+}

--- a/index.html
+++ b/index.html
@@ -21,6 +21,7 @@
     <div id="overlay-content"></div>
     <button id="overlay-button">Continua</button>
   </div>
-  <script type="module" src="main.js"></script>
+    <script src="custom-elements-patch.js"></script>
+    <script type="module" src="main.js"></script>
 </body>
 </html>

--- a/public/index.html
+++ b/public/index.html
@@ -5,9 +5,11 @@
   <title>Sprite Demo</title>
 </head>
 <body>
-  <canvas id="game" width="512" height="320"></canvas>
+    <canvas id="game" width="512" height="320"></canvas>
 
-  <script type="module">
+    <script src="../custom-elements-patch.js"></script>
+
+    <script type="module">
     import { loadSprites, Animator } from './js/preload.js';
 
     const canvas = document.getElementById('game');


### PR DESCRIPTION
## Summary
- Patch `customElements.define` to ignore re-definitions and prevent duplicate custom element errors.
- Load the patch before other scripts in both `index.html` and `public/index.html`.

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ac08b9d090832c9e7690d6ea688a6b