### PR TITLE
Fix canvas resize after showing game

### DIFF
--- a/main.js
+++ b/main.js
@@ -18,6 +18,8 @@ window.addEventListener('DOMContentLoaded', () => {
       game.reset();
     } else {
       game = new Game(canvas);
+      game.resizeCanvas();
+      game.initializeLevel();
     }
   });
 

--- a/src/game.js
+++ b/src/game.js
@@ -35,9 +35,7 @@ export class Game {
 
     this.boundResize = this.throttle(() => this.resizeCanvas(), RESIZE_THROTTLE_MS);
     window.addEventListener('resize', this.boundResize);
-    this.resizeCanvas();
 
-    this.initializeLevel();
     this.renderer = new Renderer(this);
 
     this.input = new InputHandler(() => this.handleInput());

--- a/testHelpers.js
+++ b/testHelpers.js
@@ -74,6 +74,8 @@ export function createStubGame({
   global.requestAnimationFrame = noop;
 
   const game = new Game(canvas, rng);
+  game.resizeCanvas();
+  game.initializeLevel();
   game.showOverlay = noop;
   game.gamePaused = false;
   if (skipLevelUpdate) {


### PR DESCRIPTION
## Summary
- Move canvas resizing out of `Game` constructor so layout uses visible dimensions
- Initialize and resize game only after the canvas becomes visible when pressing "Gioca"
- Adjust test helpers to explicitly resize and initialise the game

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ac10510ba8832cb4821aa233225e5f