### PR TITLE
Fix zero-sized canvas scaling

### DIFF
--- a/resizeCanvas.test.js
+++ b/resizeCanvas.test.js
@@ -1,0 +1,16 @@
+import test from 'node:test';
+import assert from 'node:assert';
+import { createStubGame } from './testHelpers.js';
+
+// If the canvas is not yet visible, getBoundingClientRect can return zeros.
+// resizeCanvas should fall back to window dimensions so the scale isn't 0.
+test('resizeCanvas falls back to window size when bounding rect is zero', () => {
+  const game = createStubGame();
+  // define window height for fallback
+  window.innerHeight = 600;
+  // simulate zero-sized bounding box
+  game.canvas.getBoundingClientRect = () => ({ width: 0, height: 0 });
+  game.resizeCanvas();
+  assert.ok(game.scale > 0);
+  assert.strictEqual(game.player.spriteScale, game.scale);
+});

--- a/src/game.js
+++ b/src/game.js
@@ -95,7 +95,14 @@ export class Game {
 
     // Determine the on-screen size of the canvas to compute the current
     // scaling factor used for player and obstacle dimensions.
-    const { width, height } = this.canvas.getBoundingClientRect();
+    let { width, height } = this.canvas.getBoundingClientRect();
+    if (width === 0 || height === 0) {
+      // If called before the canvas is visible, its bounding box may report
+      // zero dimensions. Fall back to the window size so that scaling never
+      // becomes zero and sprites render correctly on first load.
+      width = window.innerWidth;
+      height = window.innerHeight;
+    }
     const widthScale = width / BASE_WIDTH;
     const heightScale = height / BASE_HEIGHT;
     this.scale = Math.min(widthScale, heightScale, 2);


### PR DESCRIPTION
## Summary
- Avoid 0 scale by falling back to `window.innerWidth`/`innerHeight` when `getBoundingClientRect` reports zero size.
- Add regression test for canvas resize scale fallback.

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68ac116cb4a0832cb6ba37f6f89daea0