### PR TITLE
Restore game initialization

### DIFF
--- a/src/game.js
+++ b/src/game.js
@@ -36,6 +36,9 @@ export class Game {
     this.boundResize = this.throttle(() => this.resizeCanvas(), RESIZE_THROTTLE_MS);
     window.addEventListener('resize', this.boundResize);
 
+    this.resizeCanvas();
+    this.initializeLevel();
+
     this.renderer = new Renderer(this);
 
     this.input = new InputHandler(() => this.handleInput());


### PR DESCRIPTION
## Summary
- ensure Game constructor initializes canvas and level
- create player and level at start to avoid blank game state

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ac14f6c788832cb7b97a6da79d4993