### PR TITLE
refactor: remove redundant level initialization

### DIFF
--- a/main.js
+++ b/main.js
@@ -19,7 +19,6 @@ window.addEventListener('DOMContentLoaded', () => {
     } else {
       game = new Game(canvas);
       game.resizeCanvas();
-      game.initializeLevel();
     }
   });
 


### PR DESCRIPTION
## Summary
- avoid duplicate initialization when starting the game by removing `initializeLevel` call from the Play button handler
- rely on `Game` constructor for level setup, while still resizing canvas when it becomes visible

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ac15a29048832cbeeeaf3bb26c2ad3