### PR TITLE
Fix animation loop to continue after first frame

### DIFF
--- a/src/game.js
+++ b/src/game.js
@@ -180,6 +180,7 @@ export class Game {
   loop(timestamp) {
     if (this.lastTime === null) {
       this.lastTime = timestamp;
+      requestAnimationFrame(ts => this.loop(ts));
       return;
     }
     let delta = (timestamp - this.lastTime) / 1000;


### PR DESCRIPTION
## Summary
- ensure Game.loop schedules another frame on first timestamp so animation doesn't stop

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ac2b5c543c832ca413395bf713ffe3