### PR TITLE
Remove redundant resizeCanvas call

### DIFF
--- a/main.js
+++ b/main.js
@@ -18,7 +18,6 @@ window.addEventListener('DOMContentLoaded', () => {
       game.reset();
     } else {
       game = new Game(canvas);
-      game.resizeCanvas();
     }
   });
 


### PR DESCRIPTION
## Summary
- Remove unnecessary `resizeCanvas` call when starting the game; the constructor already handles resizing.

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ac2c32ec2c832c9030e53f35f3d54d