### PR TITLE
Fix game scale initialization

### DIFF
--- a/main.js
+++ b/main.js
@@ -19,6 +19,7 @@ window.addEventListener('DOMContentLoaded', () => {
     } else {
       game = new Game(canvas);
     }
+    game.resizeCanvas();
   });
 
   instructionsButton.addEventListener('click', () => {

--- a/src/game.js
+++ b/src/game.js
@@ -36,7 +36,6 @@ export class Game {
     this.boundResize = this.throttle(() => this.resizeCanvas(), RESIZE_THROTTLE_MS);
     window.addEventListener('resize', this.boundResize);
 
-    this.resizeCanvas();
     this.initializeLevel();
 
     this.renderer = new Renderer(this);


### PR DESCRIPTION
## Summary
- Ensure canvas resizing occurs only after the game canvas is visible by moving `resizeCanvas()` call to the Play button handler
- Remove premature `resizeCanvas()` invocation from `Game` constructor so scale calculation uses real canvas size

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ac2d6ac588832c97736f05424c7340