### PR TITLE
feat: add fixed 16x9 world and adaptive viewport

### DIFF
--- a/coins.test.js
+++ b/coins.test.js
@@ -9,7 +9,7 @@ const FRAME = 1 / 60;
 
 test('awards coin for passed obstacle and preserves coins in level 2', () => {
   const game = createStubGame();
-  const obstacle = new Obstacle(game.player.x - 50, game.groundY, 40, 80);
+  const obstacle = new Obstacle(game.player.x - 0.5, game.groundY, 0.4, 0.8);
   obstacle.coinAwarded = false;
   game.level.obstacles.push(obstacle);
 

--- a/collision.test.js
+++ b/collision.test.js
@@ -2,7 +2,7 @@ import test from 'node:test';
 import assert from 'node:assert';
 import { isColliding } from './collision.js';
 
-const groundY = 150;
+const groundY = 1.5;
 
 // helper to create unicorn/obstacle with bottom-based y coordinate
 function createEntity(x, y, width, height) {
@@ -10,31 +10,31 @@ function createEntity(x, y, width, height) {
 }
 
 test('detects collision when overlapping at ground', () => {
-  const unicorn = createEntity(50, groundY, 80, 80);
-  const obstacle = createEntity(60, groundY, 40, 80);
+  const unicorn = createEntity(0.5, groundY, 0.8, 0.8);
+  const obstacle = createEntity(0.6, groundY, 0.4, 0.8);
   assert.strictEqual(isColliding(unicorn, obstacle), true);
 });
 
 test('no collision when apart horizontally', () => {
-  const unicorn = createEntity(50, groundY, 80, 80);
-  const obstacle = createEntity(200, groundY, 40, 80);
+  const unicorn = createEntity(0.5, groundY, 0.8, 0.8);
+  const obstacle = createEntity(2, groundY, 0.4, 0.8);
   assert.strictEqual(isColliding(unicorn, obstacle), false);
 });
 
 test('no collision with vertical separation', () => {
-  const unicorn = createEntity(50, groundY - 120, 80, 80); // jump high
-  const obstacle = createEntity(50, groundY, 40, 80);
+  const unicorn = createEntity(0.5, groundY - 1.2, 0.8, 0.8); // jump high
+  const obstacle = createEntity(0.5, groundY, 0.4, 0.8);
   assert.strictEqual(isColliding(unicorn, obstacle), false);
 });
 
 test('detects collision on partial overlap', () => {
-  const unicorn = createEntity(55, groundY, 80, 80);
-  const obstacle = createEntity(80, groundY, 60, 80);
+  const unicorn = createEntity(0.55, groundY, 0.8, 0.8);
+  const obstacle = createEntity(0.8, groundY, 0.6, 0.8);
   assert.strictEqual(isColliding(unicorn, obstacle), true);
 });
 
 test('detects collision while jumping into obstacle', () => {
-  const unicorn = createEntity(50, groundY - 30, 80, 80); // mid-air
-  const obstacle = createEntity(60, groundY, 40, 60);
+  const unicorn = createEntity(0.5, groundY - 0.3, 0.8, 0.8); // mid-air
+  const obstacle = createEntity(0.6, groundY, 0.4, 0.6);
   assert.strictEqual(isColliding(unicorn, obstacle), true);
 });

--- a/earlyJump.test.js
+++ b/earlyJump.test.js
@@ -9,7 +9,7 @@ const FRAME = 1 / 60;
 test('player can jump early without landing on obstacle', () => {
   const game = createStubGame();
   const obstacle = game.level.createObstacle();
-  obstacle.x = 174; // far enough that player previously landed on it
+  obstacle.x = 1.74; // far enough that player previously landed on it
   obstacle.y = game.groundY;
   game.level.obstacles = [obstacle];
 

--- a/jumpScale.test.js
+++ b/jumpScale.test.js
@@ -6,7 +6,8 @@ import { JUMP_VELOCITY, GRAVITY } from './src/config.js';
 const FRAME = 1 / 60;
 
 function simulate(innerWidth) {
-  const game = createStubGame({ innerWidth, skipLevelUpdate: true });
+  const innerHeight = innerWidth * 9 / 16;
+  const game = createStubGame({ innerWidth, innerHeight, skipLevelUpdate: true });
   const { player, groundY } = game;
   const jumpDuration = (-2 * JUMP_VELOCITY) / GRAVITY;
   const framesToLand = Math.ceil(jumpDuration / FRAME);
@@ -20,8 +21,8 @@ function simulate(innerWidth) {
 }
 
 test('jump height and timing unaffected by sprite scale', () => {
-  const normal = simulate(800); // scale ~1
-  const scaled = simulate(1600); // scale ~2
+  const normal = simulate(1600); // scale ~1
+  const scaled = simulate(3200); // scale ~2
   assert.ok(Math.abs(normal.finalY - scaled.finalY) < 1e-6);
   assert.ok(Math.abs(normal.minY - scaled.minY) < 1e-6);
 });

--- a/level2.test.js
+++ b/level2.test.js
@@ -29,9 +29,9 @@ test('boss does not flee before player covers 70% of distance', () => {
 });
 
 test('boss initial position uses resized canvas width', () => {
-  const game = createStubGame({ canvasWidth: 300, innerWidth: 800, search: '?level=2', skipLevelUpdate: true });
+  const game = createStubGame({ canvasWidth: 300, innerWidth: 800, innerHeight: 450, search: '?level=2', skipLevelUpdate: true });
   assert.strictEqual(game.canvas.width, 800);
-  assert.strictEqual(game.level.boss.x, 700);
+  assert.strictEqual(game.level.boss.x, game.worldWidth - 1);
 });
 
 test('shield deactivates even when input is spammed', () => {
@@ -61,7 +61,7 @@ test('shield blocks obstacles slightly earlier', () => {
   const level = game.level;
   const player = game.player;
   const wall = level.createObstacle();
-  const gap = 5;
+  const gap = 0.05;
   wall.x = player.x + player.width + gap;
 
   // Without shield the obstacle should pass

--- a/resizeCanvas.test.js
+++ b/resizeCanvas.test.js
@@ -6,11 +6,10 @@ import { createStubGame } from './testHelpers.js';
 // resizeCanvas should fall back to window dimensions so the scale isn't 0.
 test('resizeCanvas falls back to window size when bounding rect is zero', () => {
   const game = createStubGame();
-  // define window height for fallback
-  window.innerHeight = 600;
-  // simulate zero-sized bounding box
+  window.innerWidth = 1000;
+  window.innerHeight = 500;
   game.canvas.getBoundingClientRect = () => ({ width: 0, height: 0 });
   game.resizeCanvas();
   assert.ok(game.scale > 0);
-  assert.strictEqual(game.player.spriteScale, game.scale);
+  assert.ok(Math.abs(game.canvas.width / game.canvas.height - 16 / 9) < 1e-6);
 });

--- a/src/config.js
+++ b/src/config.js
@@ -1,12 +1,19 @@
-export const GAME_SPEED = 180;
+export const WORLD_WIDTH = 16;
+export const WORLD_HEIGHT = 9;
+
+// Speeds and distances are expressed in world units. In production one world
+// unit corresponds to roughly 100 screen pixels when the canvas is displayed
+// at its default size. Using logical units keeps gameplay consistent across
+// different viewport resolutions.
+export const GAME_SPEED = 1.8; // world units per second
 // Lower the jump height while keeping the fall speed the same.
-export const GRAVITY = 1350;
+export const GRAVITY = 13.5; // world units per second^2
 export const LEVEL_UP_SCORE = 1000;
 // Further reduce the upward launch velocity so jumps clear obstacles with a small margin.
-export const JUMP_VELOCITY = -620;
+export const JUMP_VELOCITY = -6.2; // world units per second
 // Delay between canvas resize adjustments (ms)
 export const RESIZE_THROTTLE_MS = 200;
-// Extra reach for the level 2 shield in pixels (before scaling)
-export const SHIELD_RANGE = 10;
+// Extra reach for the level 2 shield in world units
+export const SHIELD_RANGE = 0.1;
 // Default shield cooldown duration in seconds
 export const SHIELD_COOLDOWN = 0.5;

--- a/src/levels/baseLevel.js
+++ b/src/levels/baseLevel.js
@@ -17,10 +17,10 @@ export class BaseLevel {
 
   createObstacle() {
     const obstacle = new Obstacle(
-      this.game.canvas.width,
+      this.game.worldWidth,
       this.game.groundY,
-      40,
-      80
+      0.4,
+      0.8
     );
     obstacle.setScale(this.game.scale);
     obstacle.imageIndex = Math.floor(this.random() * 3);

--- a/src/levels/level1.js
+++ b/src/levels/level1.js
@@ -3,6 +3,6 @@ import { BaseLevel } from './baseLevel.js';
 export class Level1 extends BaseLevel {
   getMoveSpeed() {
     // Increase tree velocity so the princess can pass them more easily.
-    return this.game.speed + 60;
+    return this.game.speed + 0.6;
   }
 }

--- a/src/levels/level2.js
+++ b/src/levels/level2.js
@@ -8,10 +8,10 @@ export class Level2 extends BaseLevel {
     super(game, random);
     this.interval = 90 / 60; // seconds
     this.boss = {
-      x: game.canvas.width - 100,
+      x: game.worldWidth - 1,
       y: game.groundY,
-      width: 80,
-      height: 100,
+      width: 0.8,
+      height: 1,
       spriteScale: game.scale,
     };
     this.bossFlee = false;
@@ -35,7 +35,7 @@ export class Level2 extends BaseLevel {
   createObstacle() {
     // The knight's thrown wall should be half as thick
     // Width reduced from 60 to 30 before scaling
-    const wall = new Obstacle(this.boss.x, this.game.groundY, 30, 100);
+    const wall = new Obstacle(this.boss.x, this.game.groundY, 0.3, 1);
     wall.setScale(this.game.scale);
     return wall;
   }
@@ -54,11 +54,11 @@ export class Level2 extends BaseLevel {
 
     if (isColliding(collider, w)) {
       if (player.shieldActive) {
-        player.x += 20;
+        player.x += 0.2;
         this.coins.push({
           x: w.x + w.width / 2,
           y: w.y - w.height / 2,
-          vy: -120,
+          vy: -1.2,
           life: 0.5,
         });
         this.game.coins++;
@@ -82,10 +82,10 @@ export class Level2 extends BaseLevel {
     this.coins.forEach(c => {
       c.x -= move;
       c.y += c.vy * delta;
-      c.vy += 6 * delta;
+      c.vy += 0.06 * delta;
       c.life -= delta;
     });
-    this.coins = this.coins.filter(c => c.life > 0 && c.x > -10);
+    this.coins = this.coins.filter(c => c.life > 0 && c.x > -0.1);
 
     const currentDistance =
       this.boss.x - (this.game.player.x + this.game.player.width);
@@ -94,7 +94,7 @@ export class Level2 extends BaseLevel {
     }
     if (this.bossFlee) {
       this.boss.x += move;
-      if (this.boss.x > this.game.canvas.width) {
+      if (this.boss.x > this.game.worldWidth) {
         this.game.gameOver = true;
         this.game.win = true;
       }

--- a/src/player.js
+++ b/src/player.js
@@ -4,8 +4,8 @@ export class Player {
   constructor(x, groundY, scale = 1) {
     this.x = x;
     this.y = groundY; // bottom position
-    this.baseWidth = 80;
-    this.baseHeight = 80;
+    this.baseWidth = 0.8;
+    this.baseHeight = 0.8;
     // Physical hitbox dimensions remain in world units, independent of the
     // sprite scale used for rendering.
     this.width = this.baseWidth;
@@ -58,7 +58,7 @@ export class Player {
     }
   }
 
-  die(speed = -200) {
+  die(speed = -2) {
     this.dead = true;
     this.vy = speed;
   }

--- a/src/renderer.js
+++ b/src/renderer.js
@@ -79,16 +79,16 @@ export class Renderer {
     const { game } = this;
     this.withContext(ctx => {
       ctx.fillStyle = '#555';
-      ctx.fillRect(0, game.groundY, game.canvas.width, 2);
+      ctx.fillRect(0, game.groundY * game.scale, game.canvas.width, 2);
     });
   }
 
   drawPlayer() {
     const u = this.game.player;
     this.withContext(ctx => {
-      const spriteScale = u.spriteScale || 1;
-      const scaledWidth = u.width * spriteScale;
-      const scaledHeight = u.height * spriteScale;
+      const scale = this.game.scale;
+      const scaledWidth = u.width * scale;
+      const scaledHeight = u.height * scale;
 
       if (this.playerSprites) {
         const now = typeof performance !== 'undefined' ? performance.now() : Date.now();
@@ -103,40 +103,40 @@ export class Renderer {
           this.playerFrameIndex = (this.playerFrameIndex + 1) % frames.length;
         }
         const img = frames[this.playerFrameIndex];
-        ctx.drawImage(img, u.x, u.y - scaledHeight, scaledWidth, scaledHeight);
+        ctx.drawImage(img, u.x * scale, (u.y - u.height) * scale, scaledWidth, scaledHeight);
       } else {
         ctx.fillStyle = '#fff';
-        ctx.fillRect(u.x, u.y - scaledHeight, scaledWidth, scaledHeight);
-        ctx.fillRect(u.x + scaledWidth - 10, u.y - scaledHeight - 10, 10, 10);
+        ctx.fillRect(u.x * scale, (u.y - u.height) * scale, scaledWidth, scaledHeight);
+        ctx.fillRect(u.x * scale + scaledWidth - 10, (u.y - u.height) * scale - 10, 10, 10);
         ctx.fillStyle = 'gold';
         ctx.beginPath();
-        ctx.moveTo(u.x + scaledWidth, u.y - scaledHeight - 10);
-        ctx.lineTo(u.x + scaledWidth + 10, u.y - scaledHeight - 30);
-        ctx.lineTo(u.x + scaledWidth, u.y - scaledHeight - 20);
+        ctx.moveTo(u.x * scale + scaledWidth, (u.y - u.height) * scale - 10);
+        ctx.lineTo(u.x * scale + scaledWidth + 10, (u.y - u.height) * scale - 30);
+        ctx.lineTo(u.x * scale + scaledWidth, (u.y - u.height) * scale - 20);
         ctx.fill();
         ctx.fillStyle = 'pink';
-        ctx.fillRect(u.x + 5, u.y - scaledHeight - 25, 15, 15);
+        ctx.fillRect(u.x * scale + 5, (u.y - u.height) * scale - 25, 15, 15);
         ctx.fillStyle = '#f2d6cb';
         ctx.beginPath();
-        ctx.arc(u.x + 12.5, u.y - scaledHeight - 30, 7, 0, Math.PI * 2);
+        ctx.arc(u.x * scale + 12.5, (u.y - u.height) * scale - 30, 7, 0, Math.PI * 2);
         ctx.fill();
       }
       if (u.shieldActive) {
-        const extra = SHIELD_RANGE * spriteScale;
+        const extra = SHIELD_RANGE * scale;
         if (this.shieldSprite) {
           const img = this.shieldSprite;
           const w = (img.width || scaledWidth) + extra * 2;
           const h = (img.height || scaledHeight) + extra * 2;
-          const sx = u.x + scaledWidth / 2 - w / 2;
-          const sy = u.y - scaledHeight / 2 - h / 2;
+          const sx = u.x * scale + scaledWidth / 2 - w / 2;
+          const sy = (u.y - u.height) * scale + scaledHeight / 2 - h / 2;
           ctx.drawImage(img, sx, sy, w, h);
         } else {
           ctx.strokeStyle = 'blue';
           ctx.lineWidth = 3;
           ctx.beginPath();
           ctx.arc(
-            u.x + scaledWidth / 2,
-            u.y - scaledHeight / 2,
+            u.x * scale + scaledWidth / 2,
+            (u.y - u.height) * scale + scaledHeight / 2,
             scaledWidth + extra,
             0,
             Math.PI * 2,
@@ -150,16 +150,18 @@ export class Renderer {
   drawObstacles() {
     const { game } = this;
     this.withContext(ctx => {
+      const scale = this.game.scale;
       game.level.obstacles.forEach(o => {
-        const scale = o.spriteScale || 1;
         const w = o.width * scale;
         const h = o.height * scale;
+        const x = o.x * scale;
+        const y = (o.y - o.height) * scale;
         if (this.treeSprites) {
           const img = this.treeSprites[(o.imageIndex ?? 0) % this.treeSprites.length];
-          ctx.drawImage(img, o.x, o.y - h, w, h);
+          ctx.drawImage(img, x, y, w, h);
         } else {
           ctx.fillStyle = 'green';
-          ctx.fillRect(o.x, o.y - h, w, h);
+          ctx.fillRect(x, y, w, h);
         }
       });
     });
@@ -168,25 +170,24 @@ export class Renderer {
   drawWalls() {
     const { game } = this;
     this.withContext(ctx => {
+      const scale = this.game.scale;
       if (this.wallSprite) {
         game.level.walls.forEach(w => {
-          const scale = w.spriteScale || 1;
           const wWidth = w.width * scale;
           const wHeight = w.height * scale;
-          ctx.drawImage(this.wallSprite, w.x, w.y - wHeight, wWidth, wHeight);
+          ctx.drawImage(this.wallSprite, w.x * scale, (w.y - w.height) * scale, wWidth, wHeight);
         });
       } else {
         ctx.fillStyle = 'gray';
         game.level.walls.forEach(w => {
-          const scale = w.spriteScale || 1;
           const wWidth = w.width * scale;
           const wHeight = w.height * scale;
-          ctx.fillRect(w.x, w.y - wHeight, wWidth, wHeight);
+          ctx.fillRect(w.x * scale, (w.y - w.height) * scale, wWidth, wHeight);
         });
       }
       const b = game.level.boss;
-      const bw = b.width * (b.spriteScale || 1);
-      const bh = b.height * (b.spriteScale || 1);
+      const bw = b.width * scale;
+      const bh = b.height * scale;
       if (this.knightSprites) {
         const now = typeof performance !== 'undefined' ? performance.now() : Date.now();
         if (!this.lastKnightTime) this.lastKnightTime = now;
@@ -198,10 +199,10 @@ export class Renderer {
           this.knightFrameIndex = (this.knightFrameIndex + 1) % this.knightSprites.length;
         }
         const img = this.knightSprites[this.knightFrameIndex];
-        ctx.drawImage(img, b.x, b.y - bh, bw, bh);
+        ctx.drawImage(img, b.x * scale, (b.y - b.height) * scale, bw, bh);
       } else {
         ctx.fillStyle = 'black';
-        ctx.fillRect(b.x, b.y - bh, bw, bh);
+        ctx.fillRect(b.x * scale, (b.y - b.height) * scale, bw, bh);
       }
     });
   }
@@ -210,9 +211,10 @@ export class Renderer {
     const { game } = this;
     this.withContext(ctx => {
       ctx.fillStyle = 'gold';
+      const scale = this.game.scale;
       game.level.coins.forEach(c => {
         ctx.beginPath();
-        ctx.arc(c.x, c.y, 5, 0, Math.PI * 2);
+        ctx.arc(c.x * scale, c.y * scale, 0.05 * scale, 0, Math.PI * 2);
         ctx.fill();
       });
     });

--- a/testHelpers.js
+++ b/testHelpers.js
@@ -2,8 +2,9 @@ import { Game } from './src/game.js';
 
 export function createStubGame({
   rng,
-  canvasWidth = 800,
-  innerWidth = 800,
+  canvasWidth = 1600,
+  innerWidth = 1600,
+  innerHeight = 900,
   search = '',
   skipLevelUpdate = false,
 } = {}) {
@@ -23,13 +24,14 @@ export function createStubGame({
   const canvas = {
     width: canvasWidth,
     height: 200,
+    style: { width: `${innerWidth}px`, height: `${innerHeight}px` },
     getContext: () => ctx,
     // Simulate how the canvas would be displayed in the browser so that
     // resize logic relying on its on-screen dimensions behaves consistently
     // in tests.
     getBoundingClientRect: () => ({
       width: innerWidth,
-      height: innerWidth * 0.75, // maintain 4:3 ratio
+      height: innerHeight,
     }),
   };
   const overlay = { classList: { add: noop, remove: noop } };
@@ -57,6 +59,7 @@ export function createStubGame({
   const eventListeners = {};
   global.window = {
     innerWidth,
+    innerHeight,
     location: { search },
     addEventListener: (event, handler) => {
       eventListeners[event] = handler;


### PR DESCRIPTION
## Summary
- define world units and convert gameplay constants to unit-based values
- implement 16:9 adaptive canvas with letter/pillar boxing
- render entities and spawn obstacles using world coordinates

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ac33864b98832ca4d4cdeb03b4451e