### PR TITLE
Use logical hitboxes for consistent collisions

### DIFF
--- a/coins.test.js
+++ b/coins.test.js
@@ -9,7 +9,15 @@ const FRAME = 1 / 60;
 
 test('awards coin for passed obstacle and preserves coins in level 2', () => {
   const game = createStubGame();
-  const obstacle = new Obstacle(game.player.x - 0.5, game.groundY, 0.4, 0.8);
+  const width = 0.4;
+  const height = 0.8;
+  const obstacleLeft = (game.player.x - game.player.width / 2) - 0.5;
+  const obstacle = new Obstacle(
+    obstacleLeft + width / 2,
+    game.groundY - height / 2,
+    width,
+    height
+  );
   obstacle.coinAwarded = false;
   game.level.obstacles.push(obstacle);
 

--- a/collision.js
+++ b/collision.js
@@ -1,13 +1,13 @@
 export function isColliding(a, b) {
-  const aLeft = a.x;
-  const aRight = a.x + a.width;
-  const aTop = a.y - a.height;
-  const aBottom = a.y;
+  const aLeft = a.x - a.width / 2;
+  const aRight = a.x + a.width / 2;
+  const aTop = a.y - a.height / 2;
+  const aBottom = a.y + a.height / 2;
 
-  const bLeft = b.x;
-  const bRight = b.x + b.width;
-  const bTop = b.y - b.height;
-  const bBottom = b.y;
+  const bLeft = b.x - b.width / 2;
+  const bRight = b.x + b.width / 2;
+  const bTop = b.y - b.height / 2;
+  const bBottom = b.y + b.height / 2;
 
   return (
     aLeft < bRight &&

--- a/collision.test.js
+++ b/collision.test.js
@@ -4,9 +4,15 @@ import { isColliding } from './collision.js';
 
 const groundY = 1.5;
 
-// helper to create unicorn/obstacle with bottom-based y coordinate
+// Helper to create entities using left/bottom coordinates for convenience
+// while the collision system operates on center-based coordinates.
 function createEntity(x, y, width, height) {
-  return { x, y, width, height };
+  return {
+    x: x + width / 2,
+    y: y - height / 2,
+    width,
+    height,
+  };
 }
 
 test('detects collision when overlapping at ground', () => {

--- a/earlyJump.test.js
+++ b/earlyJump.test.js
@@ -9,8 +9,8 @@ const FRAME = 1 / 60;
 test('player can jump early without landing on obstacle', () => {
   const game = createStubGame();
   const obstacle = game.level.createObstacle();
-  obstacle.x = 1.74; // far enough that player previously landed on it
-  obstacle.y = game.groundY;
+  obstacle.x = 1.74 + obstacle.width / 2; // position by left edge
+  obstacle.y = game.groundY - obstacle.height / 2;
   game.level.obstacles = [obstacle];
 
   game.player.jump();

--- a/jumpScale.test.js
+++ b/jumpScale.test.js
@@ -8,11 +8,11 @@ const FRAME = 1 / 60;
 function simulate(innerWidth) {
   const innerHeight = innerWidth * 9 / 16;
   const game = createStubGame({ innerWidth, innerHeight, skipLevelUpdate: true });
-  const { player, groundY } = game;
+  const { player } = game;
   const jumpDuration = (-2 * JUMP_VELOCITY) / GRAVITY;
   const framesToLand = Math.ceil(jumpDuration / FRAME);
   player.jump();
-  let minY = groundY;
+  let minY = player.y;
   for (let i = 0; i < framesToLand; i++) {
     game.update(FRAME);
     if (player.y < minY) minY = player.y;

--- a/landing.test.js
+++ b/landing.test.js
@@ -17,6 +17,6 @@ test('player lands within expected time after jumping', () => {
     game.update(FRAME);
   }
 
-  assert.strictEqual(player.y, groundY);
+  assert.strictEqual(player.y, groundY - player.height / 2);
   assert.ok(!player.jumping);
 });

--- a/level2.test.js
+++ b/level2.test.js
@@ -9,10 +9,13 @@ const FRAME = 1 / 60;
 test('boss flees after player covers 70% of distance', () => {
   const game = createStubGame({ skipLevelUpdate: true });
   const level = new Level2(game);
-  const initialDistance = level.boss.x - (game.player.x + game.player.width);
+  const initialDistance =
+    (level.boss.x - level.boss.width / 2) -
+    (game.player.x + game.player.width / 2);
   const threshold = initialDistance * 0.3;
 
-  game.player.x = level.boss.x - threshold - game.player.width;
+  game.player.x =
+    level.boss.x - level.boss.width / 2 - threshold - game.player.width / 2;
   level.update(FRAME);
   assert.ok(level.bossFlee);
 });
@@ -20,10 +23,13 @@ test('boss flees after player covers 70% of distance', () => {
 test('boss does not flee before player covers 70% of distance', () => {
   const game = createStubGame({ skipLevelUpdate: true });
   const level = new Level2(game);
-  const initialDistance = level.boss.x - (game.player.x + game.player.width);
+  const initialDistance =
+    (level.boss.x - level.boss.width / 2) -
+    (game.player.x + game.player.width / 2);
   const almostThreshold = initialDistance * 0.31;
 
-  game.player.x = level.boss.x - almostThreshold - game.player.width;
+  game.player.x =
+    level.boss.x - level.boss.width / 2 - almostThreshold - game.player.width / 2;
   level.update(FRAME);
   assert.ok(!level.bossFlee);
 });
@@ -31,7 +37,7 @@ test('boss does not flee before player covers 70% of distance', () => {
 test('boss initial position uses resized canvas width', () => {
   const game = createStubGame({ canvasWidth: 300, innerWidth: 800, innerHeight: 450, search: '?level=2', skipLevelUpdate: true });
   assert.strictEqual(game.canvas.width, 800);
-  assert.strictEqual(game.level.boss.x, game.worldWidth - 1);
+  assert.strictEqual(game.level.boss.x, game.worldWidth - 1 + 0.8 / 2);
 });
 
 test('shield deactivates even when input is spammed', () => {
@@ -62,7 +68,7 @@ test('shield blocks obstacles slightly earlier', () => {
   const player = game.player;
   const wall = level.createObstacle();
   const gap = 0.05;
-  wall.x = player.x + player.width + gap;
+  wall.x = player.x + player.width / 2 + gap + wall.width / 2;
 
   // Without shield the obstacle should pass
   assert.ok(level.handleCollision(wall));

--- a/src/game.js
+++ b/src/game.js
@@ -59,7 +59,8 @@ export class Game {
   }
 
   initializeLevel() {
-    this.player = new Player(0.5, this.groundY, this.scale);
+    const startX = 0.5 + 0.8 / 2;
+    this.player = new Player(startX, this.groundY, this.scale);
     this.level = this.levelNumber === 1 ? new Level1(this, this.random) : new Level2(this, this.random);
     if (typeof this.level.setScale === 'function') {
       this.level.setScale(this.scale);
@@ -115,7 +116,7 @@ export class Game {
     if (this.player) {
       this.player.setScale(this.scale);
       if (!this.player.jumping) {
-        this.player.y = this.groundY;
+        this.player.y = this.groundY - this.player.height / 2;
       }
     }
     if (this.level && typeof this.level.setScale === 'function') {

--- a/src/levels/baseLevel.js
+++ b/src/levels/baseLevel.js
@@ -16,11 +16,13 @@ export class BaseLevel {
   }
 
   createObstacle() {
+    const width = 0.4;
+    const height = 0.8;
     const obstacle = new Obstacle(
-      this.game.worldWidth,
-      this.game.groundY,
-      0.4,
-      0.8
+      this.game.worldWidth + width / 2,
+      this.game.groundY - height / 2,
+      width,
+      height
     );
     obstacle.setScale(this.game.scale);
     obstacle.imageIndex = Math.floor(this.random() * 3);
@@ -59,7 +61,9 @@ export class BaseLevel {
       o.update(move);
     });
     this.obstacles = this.obstacles.filter(o => {
-      if (o.x + o.width < this.game.player.x) {
+      const obstacleRight = o.x + o.width / 2;
+      const playerLeft = this.game.player.x - this.game.player.width / 2;
+      if (obstacleRight < playerLeft) {
         this.onObstaclePassed(o);
         return false;
       }

--- a/src/levels/level2.js
+++ b/src/levels/level2.js
@@ -8,8 +8,8 @@ export class Level2 extends BaseLevel {
     super(game, random);
     this.interval = 90 / 60; // seconds
     this.boss = {
-      x: game.worldWidth - 1,
-      y: game.groundY,
+      x: game.worldWidth - 1 + 0.8 / 2,
+      y: game.groundY - 1 / 2,
       width: 0.8,
       height: 1,
       spriteScale: game.scale,
@@ -17,7 +17,8 @@ export class Level2 extends BaseLevel {
     this.bossFlee = false;
     this.coins = [];
     this.initialDistance =
-      this.boss.x - (this.game.player.x + this.game.player.width);
+      (this.boss.x - this.boss.width / 2) -
+      (this.game.player.x + this.game.player.width / 2);
   }
 
   static getInterval(random) {
@@ -35,7 +36,14 @@ export class Level2 extends BaseLevel {
   createObstacle() {
     // The knight's thrown wall should be half as thick
     // Width reduced from 60 to 30 before scaling
-    const wall = new Obstacle(this.boss.x, this.game.groundY, 0.3, 1);
+    const width = 0.3;
+    const height = 1;
+    const wall = new Obstacle(
+      this.boss.x - this.boss.width / 2 + width / 2,
+      this.game.groundY - height / 2,
+      width,
+      height
+    );
     wall.setScale(this.game.scale);
     return wall;
   }
@@ -49,15 +57,15 @@ export class Level2 extends BaseLevel {
     // rendering scale.
     const range = player.shieldActive ? SHIELD_RANGE : 0;
     const collider = player.shieldActive
-      ? { x: player.x - range, y: player.y, width: player.width + range * 2, height: player.height }
+      ? { x: player.x, y: player.y, width: player.width + range * 2, height: player.height }
       : player;
 
     if (isColliding(collider, w)) {
       if (player.shieldActive) {
         player.x += 0.2;
         this.coins.push({
-          x: w.x + w.width / 2,
-          y: w.y - w.height / 2,
+          x: w.x,
+          y: w.y,
           vy: -1.2,
           life: 0.5,
         });
@@ -76,7 +84,7 @@ export class Level2 extends BaseLevel {
       super.updateObstacles(delta);
     } else {
       this.obstacles.forEach(w => w.update(move));
-      this.obstacles = this.obstacles.filter(w => w.x + w.width > 0);
+      this.obstacles = this.obstacles.filter(w => w.x + w.width / 2 > 0);
     }
 
     this.coins.forEach(c => {
@@ -88,13 +96,14 @@ export class Level2 extends BaseLevel {
     this.coins = this.coins.filter(c => c.life > 0 && c.x > -0.1);
 
     const currentDistance =
-      this.boss.x - (this.game.player.x + this.game.player.width);
+      (this.boss.x - this.boss.width / 2) -
+      (this.game.player.x + this.game.player.width / 2);
     if (currentDistance <= this.initialDistance * 0.3) {
       this.bossFlee = true;
     }
     if (this.bossFlee) {
       this.boss.x += move;
-      if (this.boss.x > this.game.worldWidth) {
+      if (this.boss.x - this.boss.width / 2 > this.game.worldWidth) {
         this.game.gameOver = true;
         this.game.win = true;
       }

--- a/src/obstacle.js
+++ b/src/obstacle.js
@@ -1,7 +1,8 @@
 export class Obstacle {
   constructor(x, y, width, height) {
+    // x and y represent the center of the hitbox in world units.
     this.x = x;
-    this.y = y; // bottom position
+    this.y = y;
     // Store both the physical hitbox size (width/height) and the scale used
     // only for rendering. The hitbox stays in world units regardless of the
     // sprite size.

--- a/src/player.js
+++ b/src/player.js
@@ -3,13 +3,13 @@ import { JUMP_VELOCITY, SHIELD_COOLDOWN } from './config.js';
 export class Player {
   constructor(x, groundY, scale = 1) {
     this.x = x;
-    this.y = groundY; // bottom position
     this.baseWidth = 0.8;
     this.baseHeight = 0.8;
     // Physical hitbox dimensions remain in world units, independent of the
     // sprite scale used for rendering.
     this.width = this.baseWidth;
     this.height = this.baseHeight;
+    this.y = groundY - this.height / 2;
     this.spriteScale = scale;
     this.vy = 0;
     this.jumping = false;
@@ -27,8 +27,8 @@ export class Player {
   update(gravity, groundY, delta) {
     this.vy += gravity * delta;
     this.y += this.vy * delta;
-    if (this.y >= groundY) {
-      this.y = groundY;
+    if (this.y + this.height / 2 >= groundY) {
+      this.y = groundY - this.height / 2;
       this.vy = 0;
       this.jumping = false;
     }

--- a/src/renderer.js
+++ b/src/renderer.js
@@ -89,6 +89,8 @@ export class Renderer {
       const scale = this.game.scale;
       const scaledWidth = u.width * scale;
       const scaledHeight = u.height * scale;
+      const left = (u.x - u.width / 2) * scale;
+      const top = (u.y - u.height / 2) * scale;
 
       if (this.playerSprites) {
         const now = typeof performance !== 'undefined' ? performance.now() : Date.now();
@@ -103,22 +105,22 @@ export class Renderer {
           this.playerFrameIndex = (this.playerFrameIndex + 1) % frames.length;
         }
         const img = frames[this.playerFrameIndex];
-        ctx.drawImage(img, u.x * scale, (u.y - u.height) * scale, scaledWidth, scaledHeight);
+        ctx.drawImage(img, left, top, scaledWidth, scaledHeight);
       } else {
         ctx.fillStyle = '#fff';
-        ctx.fillRect(u.x * scale, (u.y - u.height) * scale, scaledWidth, scaledHeight);
-        ctx.fillRect(u.x * scale + scaledWidth - 10, (u.y - u.height) * scale - 10, 10, 10);
+        ctx.fillRect(left, top, scaledWidth, scaledHeight);
+        ctx.fillRect(left + scaledWidth - 10, top - 10, 10, 10);
         ctx.fillStyle = 'gold';
         ctx.beginPath();
-        ctx.moveTo(u.x * scale + scaledWidth, (u.y - u.height) * scale - 10);
-        ctx.lineTo(u.x * scale + scaledWidth + 10, (u.y - u.height) * scale - 30);
-        ctx.lineTo(u.x * scale + scaledWidth, (u.y - u.height) * scale - 20);
+        ctx.moveTo(left + scaledWidth, top - 10);
+        ctx.lineTo(left + scaledWidth + 10, top - 30);
+        ctx.lineTo(left + scaledWidth, top - 20);
         ctx.fill();
         ctx.fillStyle = 'pink';
-        ctx.fillRect(u.x * scale + 5, (u.y - u.height) * scale - 25, 15, 15);
+        ctx.fillRect(left + 5, top - 25, 15, 15);
         ctx.fillStyle = '#f2d6cb';
         ctx.beginPath();
-        ctx.arc(u.x * scale + 12.5, (u.y - u.height) * scale - 30, 7, 0, Math.PI * 2);
+        ctx.arc(left + 12.5, top - 30, 7, 0, Math.PI * 2);
         ctx.fill();
       }
       if (u.shieldActive) {
@@ -127,17 +129,17 @@ export class Renderer {
           const img = this.shieldSprite;
           const w = (img.width || scaledWidth) + extra * 2;
           const h = (img.height || scaledHeight) + extra * 2;
-          const sx = u.x * scale + scaledWidth / 2 - w / 2;
-          const sy = (u.y - u.height) * scale + scaledHeight / 2 - h / 2;
+          const sx = u.x * scale - w / 2;
+          const sy = u.y * scale - h / 2;
           ctx.drawImage(img, sx, sy, w, h);
         } else {
           ctx.strokeStyle = 'blue';
           ctx.lineWidth = 3;
           ctx.beginPath();
           ctx.arc(
-            u.x * scale + scaledWidth / 2,
-            (u.y - u.height) * scale + scaledHeight / 2,
-            scaledWidth + extra,
+            u.x * scale,
+            u.y * scale,
+            scaledWidth / 2 + extra,
             0,
             Math.PI * 2,
           );
@@ -154,8 +156,8 @@ export class Renderer {
       game.level.obstacles.forEach(o => {
         const w = o.width * scale;
         const h = o.height * scale;
-        const x = o.x * scale;
-        const y = (o.y - o.height) * scale;
+        const x = (o.x - o.width / 2) * scale;
+        const y = (o.y - o.height / 2) * scale;
         if (this.treeSprites) {
           const img = this.treeSprites[(o.imageIndex ?? 0) % this.treeSprites.length];
           ctx.drawImage(img, x, y, w, h);
@@ -175,19 +177,21 @@ export class Renderer {
         game.level.walls.forEach(w => {
           const wWidth = w.width * scale;
           const wHeight = w.height * scale;
-          ctx.drawImage(this.wallSprite, w.x * scale, (w.y - w.height) * scale, wWidth, wHeight);
+          ctx.drawImage(this.wallSprite, (w.x - w.width / 2) * scale, (w.y - w.height / 2) * scale, wWidth, wHeight);
         });
       } else {
         ctx.fillStyle = 'gray';
         game.level.walls.forEach(w => {
           const wWidth = w.width * scale;
           const wHeight = w.height * scale;
-          ctx.fillRect(w.x * scale, (w.y - w.height) * scale, wWidth, wHeight);
+          ctx.fillRect((w.x - w.width / 2) * scale, (w.y - w.height / 2) * scale, wWidth, wHeight);
         });
       }
       const b = game.level.boss;
       const bw = b.width * scale;
       const bh = b.height * scale;
+      const bx = (b.x - b.width / 2) * scale;
+      const by = (b.y - b.height / 2) * scale;
       if (this.knightSprites) {
         const now = typeof performance !== 'undefined' ? performance.now() : Date.now();
         if (!this.lastKnightTime) this.lastKnightTime = now;
@@ -199,10 +203,10 @@ export class Renderer {
           this.knightFrameIndex = (this.knightFrameIndex + 1) % this.knightSprites.length;
         }
         const img = this.knightSprites[this.knightFrameIndex];
-        ctx.drawImage(img, b.x * scale, (b.y - b.height) * scale, bw, bh);
+        ctx.drawImage(img, bx, by, bw, bh);
       } else {
         ctx.fillStyle = 'black';
-        ctx.fillRect(b.x * scale, (b.y - b.height) * scale, bw, bh);
+        ctx.fillRect(bx, by, bw, bh);
       }
     });
   }


### PR DESCRIPTION
## Summary
- Compute AABB collisions from hitbox centers instead of sprite bounds
- Store player and obstacle positions as center-based coordinates and update level logic and rendering
- Keep collision behavior stable regardless of sprite scaling

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ac42c27768832c910368fca96edf3f