### PR TITLE
Initialize world dimensions before level creation

### DIFF
--- a/src/game.js
+++ b/src/game.js
@@ -41,6 +41,10 @@ export class Game {
     this.boundResize = this.throttle(() => this.resizeCanvas(), RESIZE_THROTTLE_MS);
     window.addEventListener('resize', this.boundResize);
 
+    // Ensure world dimensions like groundY are set before creating the level
+    // so entities that depend on them (e.g., the boss in Level2) initialize
+    // with correct positions.
+    this.resizeCanvas();
     this.initializeLevel();
 
     this.renderer = new Renderer(this);


### PR DESCRIPTION
## Summary
- Ensure `resizeCanvas` runs before level initialization so level entities start with correct positions

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ac5bb76438832c967e5799d8a13de7