### PR TITLE
Reduce tree size and impact by 20%

### DIFF
--- a/coins.test.js
+++ b/coins.test.js
@@ -9,8 +9,8 @@ const FRAME = 1 / 60;
 
 test('awards coin for passed obstacle and preserves coins in level 2', () => {
   const game = createStubGame();
-  const width = 0.4;
-  const height = 0.8;
+  const width = 0.32;
+  const height = 0.64;
   const obstacleLeft = (game.player.x - game.player.width / 2) - 0.5;
   const obstacle = new Obstacle(
     obstacleLeft + width / 2,

--- a/collision.test.js
+++ b/collision.test.js
@@ -17,30 +17,30 @@ function createEntity(x, y, width, height) {
 
 test('detects collision when overlapping at ground', () => {
   const unicorn = createEntity(0.5, groundY, 0.8, 0.8);
-  const obstacle = createEntity(0.6, groundY, 0.4, 0.8);
+  const obstacle = createEntity(0.6, groundY, 0.32, 0.64);
   assert.strictEqual(isColliding(unicorn, obstacle), true);
 });
 
 test('no collision when apart horizontally', () => {
   const unicorn = createEntity(0.5, groundY, 0.8, 0.8);
-  const obstacle = createEntity(2, groundY, 0.4, 0.8);
+  const obstacle = createEntity(2, groundY, 0.32, 0.64);
   assert.strictEqual(isColliding(unicorn, obstacle), false);
 });
 
 test('no collision with vertical separation', () => {
   const unicorn = createEntity(0.5, groundY - 1.2, 0.8, 0.8); // jump high
-  const obstacle = createEntity(0.5, groundY, 0.4, 0.8);
+  const obstacle = createEntity(0.5, groundY, 0.32, 0.64);
   assert.strictEqual(isColliding(unicorn, obstacle), false);
 });
 
 test('detects collision on partial overlap', () => {
   const unicorn = createEntity(0.55, groundY, 0.8, 0.8);
-  const obstacle = createEntity(0.8, groundY, 0.6, 0.8);
+  const obstacle = createEntity(0.8, groundY, 0.48, 0.64);
   assert.strictEqual(isColliding(unicorn, obstacle), true);
 });
 
 test('detects collision while jumping into obstacle', () => {
   const unicorn = createEntity(0.5, groundY - 0.3, 0.8, 0.8); // mid-air
-  const obstacle = createEntity(0.6, groundY, 0.4, 0.6);
+  const obstacle = createEntity(0.6, groundY, 0.32, 0.48);
   assert.strictEqual(isColliding(unicorn, obstacle), true);
 });

--- a/src/levels/baseLevel.js
+++ b/src/levels/baseLevel.js
@@ -16,8 +16,9 @@ export class BaseLevel {
   }
 
   createObstacle() {
-    const width = 0.4;
-    const height = 0.8;
+    // Reduce tree size by 20% to make them less intrusive.
+    const width = 0.32;
+    const height = 0.64;
     const obstacle = new Obstacle(
       this.game.worldWidth + width / 2,
       this.game.groundY - height / 2,

--- a/src/levels/level1.js
+++ b/src/levels/level1.js
@@ -2,7 +2,7 @@ import { BaseLevel } from './baseLevel.js';
 
 export class Level1 extends BaseLevel {
   getMoveSpeed() {
-    // Increase tree velocity so the princess can pass them more easily.
-    return this.game.speed + 0.6;
+    // Increase tree velocity by 20% so they impact gameplay less.
+    return (this.game.speed + 0.6) * 1.2;
   }
 }


### PR DESCRIPTION
## Summary
- Shrink tree obstacles by 20% to lessen their presence
- Increase level 1 tree movement speed by 20% so obstacles affect gameplay less
- Update collision and coin tests for new obstacle dimensions

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68accb7331d8832cb0279c4dc3bfc368