### PR TITLE
Add persistent high score with UI display

### DIFF
--- a/highScore.test.js
+++ b/highScore.test.js
@@ -1,0 +1,24 @@
+import test from 'node:test';
+import assert from 'node:assert';
+import { createStubGame } from './testHelpers.js';
+
+test('reads high score from localStorage', () => {
+  localStorage.clear();
+  localStorage.setItem('highScore', '123');
+  const game = createStubGame({ skipLevelUpdate: true });
+  assert.strictEqual(game.highScore, 123);
+});
+
+test('updates high score and persists across reset and new game', () => {
+  localStorage.clear();
+  const game = createStubGame({ skipLevelUpdate: true });
+  game.score = 50;
+  game.update(0);
+  assert.strictEqual(localStorage.getItem('highScore'), '50');
+  assert.strictEqual(game.highScore, 50);
+  game.showOverlay = (_text, cb) => { if (cb) cb(); };
+  game.reset();
+  assert.strictEqual(game.highScore, 50);
+  const game2 = createStubGame({ skipLevelUpdate: true });
+  assert.strictEqual(game2.highScore, 50);
+});

--- a/src/game.js
+++ b/src/game.js
@@ -25,6 +25,8 @@ export class Game {
     this.gravity = GRAVITY; // acceleration per second^2
     this.score = 0;
     this.coins = 0;
+    const storedHigh = typeof localStorage !== 'undefined' ? localStorage.getItem('highScore') : null;
+    this.highScore = storedHigh ? parseInt(storedHigh, 10) : 0;
     this.gameOver = false;
     this.win = false;
     this.gamePaused = true;
@@ -167,6 +169,13 @@ export class Game {
       this.player.die();
     }
     if (!this.gameOver) this.score += delta * 60;
+    const current = Math.floor(this.score);
+    if (current > this.highScore) {
+      this.highScore = current;
+      if (typeof localStorage !== 'undefined') {
+        localStorage.setItem('highScore', this.highScore.toString());
+      }
+    }
 
     if (this.levelNumber === 1 && this.score >= LEVEL_UP_SCORE) {
       this.levelNumber = 2;

--- a/src/renderer.js
+++ b/src/renderer.js
@@ -250,6 +250,7 @@ export class Renderer {
       ctx.font = '16px sans-serif';
       ctx.textAlign = 'left';
       ctx.fillText(`Punteggio: ${Math.floor(game.score)}`, 10, 20);
+      ctx.fillText(`High Score: ${Math.floor(game.highScore)}`, 10, 40);
 
       const coinX = game.canvas.width - 20;
       ctx.fillStyle = 'gold';
@@ -263,16 +264,17 @@ export class Renderer {
 
       const p = game.player;
       const iconSize = 16;
+      const iconY = 48;
       if (this.shieldSprite) {
-        ctx.drawImage(this.shieldSprite, 10, 28, iconSize, iconSize);
+        ctx.drawImage(this.shieldSprite, 10, iconY, iconSize, iconSize);
       } else {
         ctx.strokeStyle = 'blue';
         ctx.beginPath();
-        ctx.arc(18, 36, 8, 0, Math.PI * 2);
+        ctx.arc(18, iconY + 8, 8, 0, Math.PI * 2);
         ctx.stroke();
       }
       const barX = 10 + iconSize + 5;
-      const barY = 30;
+      const barY = iconY + 2;
       const barWidth = 80;
       const barHeight = 10;
       ctx.strokeStyle = '#000';

--- a/testHelpers.js
+++ b/testHelpers.js
@@ -1,5 +1,24 @@
 import { Game } from './src/game.js';
 
+const localStorageStub = (() => {
+  let store = {};
+  return {
+    getItem(key) {
+      return Object.prototype.hasOwnProperty.call(store, key) ? store[key] : null;
+    },
+    setItem(key, value) {
+      store[key] = String(value);
+    },
+    removeItem(key) {
+      delete store[key];
+    },
+    clear() {
+      store = {};
+    },
+  };
+})();
+global.localStorage = localStorageStub;
+
 export function createStubGame({
   rng,
   canvasWidth = 1600,


### PR DESCRIPTION
## Summary
- track high score using `localStorage` and update when the current score exceeds it
- display the stored high score in the game UI
- test high score persistence across resets and game instances

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ace501472c832cb8b16d8ff8c96f4e