### PR TITLE
Add pause toggle and multi-key input handling

### DIFF
--- a/game.test.js
+++ b/game.test.js
@@ -1,6 +1,7 @@
 import test from 'node:test';
 import assert from 'node:assert';
 import { createStubGame } from './testHelpers.js';
+import { Game } from './src/game.js';
 import { Level2 } from './src/levels/level2.js';
 import { LEVEL_UP_SCORE } from './src/config.js';
 
@@ -70,4 +71,28 @@ test('player continues to fall after losing', () => {
   // After update, gravity should increase the vertical velocity
   game.update(FRAME);
   assert.ok(game.player.vy > initialVy);
+});
+
+test('toggles pause when pause key is pressed', () => {
+  const game = createStubGame({ skipLevelUpdate: true });
+  game.showOverlay = Game.prototype.showOverlay.bind(game);
+  let showed = false;
+  let hid = false;
+  const origShow = game.overlay.show.bind(game.overlay);
+  game.overlay.show = (text, cb) => {
+    showed = true;
+    origShow(text, cb);
+  };
+  const origHide = game.overlay.hide.bind(game.overlay);
+  game.overlay.hide = () => {
+    hid = true;
+    origHide();
+  };
+  game.gamePaused = false;
+  game.input.keyListener({ code: 'KeyP', repeat: false });
+  assert.ok(game.gamePaused);
+  assert.ok(showed);
+  game.input.keyListener({ code: 'KeyP', repeat: false });
+  assert.ok(!game.gamePaused);
+  assert.ok(hid);
 });

--- a/input.test.js
+++ b/input.test.js
@@ -16,7 +16,7 @@ test('attaches listeners with passive option by default', () => {
     },
     removeEventListener: () => {},
   };
-  const handler = new InputHandler(() => {});
+  const handler = new InputHandler({}, { pointerCallback: () => {} });
   handler.attach();
   assert.deepStrictEqual(calls, [
     { target: 'document', type: 'keydown', options: { passive: true } },
@@ -24,11 +24,16 @@ test('attaches listeners with passive option by default', () => {
   ]);
 });
 
-test('supports custom key mappings', () => {
-  let count = 0;
-  const handler = new InputHandler(() => count++, { keys: ['KeyA', 'KeyB'] });
+test('supports dedicated callbacks for keys', () => {
+  let a = 0;
+  let b = 0;
+  const handler = new InputHandler({
+    KeyA: () => a++,
+    KeyB: () => b++,
+  });
   handler.keyListener({ code: 'KeyA', repeat: false });
   handler.keyListener({ code: 'KeyB', repeat: false });
   handler.keyListener({ code: 'Space', repeat: false });
-  assert.strictEqual(count, 2);
+  assert.strictEqual(a, 1);
+  assert.strictEqual(b, 1);
 });

--- a/src/game.js
+++ b/src/game.js
@@ -51,7 +51,14 @@ export class Game {
 
     this.renderer = new Renderer(this);
 
-    this.input = new InputHandler(() => this.handleInput());
+    const keyMap = {
+      Space: () => this.handleInput('Space'),
+      KeyP: () => this.handleInput('KeyP'),
+      Escape: () => this.handleInput('Escape'),
+    };
+    this.input = new InputHandler(keyMap, {
+      pointerCallback: () => this.handleInput('Space'),
+    });
     this.input.attach();
 
     this.renderer
@@ -130,9 +137,26 @@ export class Game {
     }
   }
 
-  handleInput() {
+  togglePause() {
+    this.gamePaused = !this.gamePaused;
+    if (this.gamePaused) {
+      this.showOverlay('Game Paused', () => this.togglePause());
+    } else {
+      this.overlay.onClose = null;
+      this.overlay.hide();
+      this.lastTime = null;
+      requestAnimationFrame(ts => this.loop(ts));
+    }
+  }
+
+  handleInput(code = 'Space') {
     if (this.gameOver) {
       this.reset();
+      return;
+    }
+
+    if (code === 'KeyP' || code === 'Escape') {
+      this.togglePause();
       return;
     }
 

--- a/src/input.js
+++ b/src/input.js
@@ -1,17 +1,21 @@
 export class InputHandler {
   constructor(
-    onAction,
-    { keys = ['Space'], pointerEvent = 'pointerdown', passive = true } = {}
+    keyMap = {},
+    { pointerEvent = 'pointerdown', pointerCallback, passive = true } = {},
   ) {
-    this.onAction = onAction;
-    this.keys = keys;
+    this.keyMap = keyMap;
     this.pointerEvent = pointerEvent;
+    this.pointerCallback = pointerCallback;
     this.eventOptions = passive ? { passive: true } : undefined;
 
     this.keyListener = (e) => {
-      if (this.keys.includes(e.code) && !e.repeat) this.onAction();
+      const cb = this.keyMap[e.code];
+      if (cb && !e.repeat) cb();
     };
-    this.pointerListener = () => this.onAction();
+
+    this.pointerListener = () => {
+      if (this.pointerCallback) this.pointerCallback();
+    };
   }
 
   attach() {
@@ -26,7 +30,8 @@ export class InputHandler {
       window.removeEventListener(
         this.pointerEvent,
         this.pointerListener,
-        this.eventOptions
+        this.eventOptions,
       );
   }
 }
+


### PR DESCRIPTION
## Summary
- Support mapping multiple keys to specific callbacks in `InputHandler`
- Add `togglePause` to manage pause state and overlay updates
- Handle pause keys separately from jump/shield actions
- Test multi-key input and pause key behavior

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ace80b6edc832c8e0ed8340b7d3c37