### PR TITLE
Add audio loading and playback

### DIFF
--- a/audio.test.js
+++ b/audio.test.js
@@ -1,0 +1,44 @@
+import test from 'node:test';
+import assert from 'node:assert';
+import { Renderer } from './src/renderer.js';
+
+class AudioMock {
+  constructor() {
+    this._listeners = {};
+    this.volume = 1;
+    this.currentTime = 0;
+    this.playCalled = false;
+  }
+  addEventListener(event, handler) {
+    this._listeners[event] = handler;
+  }
+  set src(value) {
+    this._src = value;
+    setTimeout(() => {
+      if (this._listeners.canplaythrough) this._listeners.canplaythrough();
+    }, 0);
+  }
+  play() {
+    this.playCalled = true;
+  }
+}
+
+test('renderer preloads audio assets and sets volume', async () => {
+  global.Audio = AudioMock;
+  const renderer = new Renderer({ ctx: {} });
+  await renderer.preload();
+  const jump = renderer.assets.get('jump');
+  assert.ok(jump instanceof AudioMock);
+  assert.strictEqual(jump.volume, 0.5);
+});
+
+test('playSound resets time and plays audio', async () => {
+  global.Audio = AudioMock;
+  const renderer = new Renderer({ ctx: {} });
+  await renderer.preload();
+  const jump = renderer.assets.get('jump');
+  jump.currentTime = 1;
+  renderer.playSound('jump');
+  assert.strictEqual(jump.currentTime, 0);
+  assert.ok(jump.playCalled);
+});

--- a/src/assetManager.js
+++ b/src/assetManager.js
@@ -23,8 +23,36 @@ export class AssetManager {
     });
   }
 
+  loadAudio(key, src) {
+    return new Promise((resolve, reject) => {
+      if (typeof Audio === 'undefined') {
+        const audio = { src, play: () => {}, volume: 1, currentTime: 0 };
+        this.assets.set(key, audio);
+        resolve(audio);
+        return;
+      }
+      const audio = new Audio();
+      audio.addEventListener(
+        'canplaythrough',
+        () => {
+          this.assets.set(key, audio);
+          resolve(audio);
+        },
+        { once: true }
+      );
+      audio.addEventListener('error', () => {
+        reject(new Error(`Failed to load audio: ${src}`));
+      });
+      audio.src = src;
+    });
+  }
+
   loadAll(list) {
-    return Promise.all(list.map(({ key, src }) => this.loadImage(key, src)));
+    return Promise.all(
+      list.map(({ key, src, type }) =>
+        type === 'audio' ? this.loadAudio(key, src) : this.loadImage(key, src)
+      )
+    );
   }
 
   get(key) {

--- a/src/game.js
+++ b/src/game.js
@@ -164,8 +164,10 @@ export class Game {
 
     if (this.levelNumber === 1) {
       this.player.jump();
+      this.renderer.playSound('jump');
     } else {
       this.player.activateShield();
+      this.renderer.playSound('shield');
     }
   }
 

--- a/src/levels/baseLevel.js
+++ b/src/levels/baseLevel.js
@@ -39,6 +39,9 @@ export class BaseLevel {
     if (!o.coinAwarded) {
       this.game.coins++;
       o.coinAwarded = true;
+      if (this.game.renderer && this.game.renderer.playSound) {
+        this.game.renderer.playSound('coin');
+      }
     }
   }
 

--- a/src/levels/level2.js
+++ b/src/levels/level2.js
@@ -76,6 +76,10 @@ export class Level2 extends BaseLevel {
           life: 0.5,
         });
         this.game.coins++;
+        if (this.game.renderer && this.game.renderer.playSound) {
+          this.game.renderer.playSound('shield');
+          this.game.renderer.playSound('coin');
+        }
         return false;
       }
       if (!this.pendingHit) {
@@ -148,6 +152,10 @@ export class Level2 extends BaseLevel {
           life: 0.5,
         });
         this.game.coins++;
+        if (this.game.renderer && this.game.renderer.playSound) {
+          this.game.renderer.playSound('shield');
+          this.game.renderer.playSound('coin');
+        }
         this.pendingHit = null;
         this.pendingGrace = 0;
       } else {

--- a/src/renderer.js
+++ b/src/renderer.js
@@ -1,6 +1,10 @@
 import { AssetManager } from './assetManager.js';
 import { SHIELD_RANGE } from './config.js';
 
+const JUMP_SOUND = 'data:audio/wav;base64,UklGRuwAAABXQVZFZm10IBAAAAABAAEAoA8AAKAPAAABAAgAZGF0YcgAAACA/K4UKcryYAFw+L0eHr34cAFg8sopFK78fwNR69Y1DZ/+jwdC4eFCB4/+nw011utRA4D8rhQpyvJgAXD4vR4evfhwAWDyyikUrvyAA1Hr1jUNn/6PB0Lh4UIHj/6fDTXW61EDgPyuFCnK8mABcPi9Hh69+HABYPLKKRSu/H8DUevWNQ2f/o8HQuHhQgeP/p8NNdbrUQN//K4UKcryYAFw+L0eHr34cAFg8sopFK78fwNR69Y1DZ/+jwdC4eFCB4/+nw011utRAw==';
+const COIN_SOUND = 'data:audio/wav;base64,UklGRuwAAABXQVZFZm10IBAAAAABAAEAoA8AAKAPAAABAAgAZGF0YcgAAACA7e+DFA546fKLGQtw5PaTHgho3/ibIwZg2fujKQRY0/yrLwJRzf2yNQFJx/65OwFCwP/AQgE7uf7HSQE1sv3NUQIvq/zTWAQpo/vZYAYjm/jfaAgek/bkcAsZi/LpeA4Ug+/tgBIQfOvxhxYNdOb0jxsJbOH3lyAHZNz5nyYEXNb7pywDVND9rjICTcr+tjgBRsT+vT8BP73+xEYBOLb+yk0CMq790FQDLKf71lwEJp/53GQHIJf34WwJG4/05nQNFofx63wQEg==';
+const SHIELD_SOUND = 'data:audio/wav;base64,UklGRuwAAABXQVZFZm10IBAAAAABAAEAoA8AAKAPAAABAAgAZGF0YcgAAACA0PzvrlgUAil4yvvytmAZASNwxPj2vWgeAR5ovfb4xHAjARlgtvL7yngpAhRYru/80H8vAxBRp+v91oc1BA1Jn+b+3I87BwlCl+H/4ZdCCQc7j9z+5p9JDQQ1h9b966dREAMvgND8765YFAIpeMr78rZgGQEjcMT49r1oHgEeaL32+MRwIwEZYLby+8p4KQIUWK7v/NCALwMQUafr/daHNQQNSZ/m/tyPOwcJQpfh/+GXQgkHO4/c/uafSQ0ENYfW/eunURADLw==';
+
 const SPRITE_SCALE = 2;
 
 export class Renderer {
@@ -20,12 +24,10 @@ export class Renderer {
     this.knightFrameIndex = 0;
     this.knightFrameTimer = 0;
     this.lastKnightTime = 0;
+    this.sounds = {};
   }
 
   preload() {
-    if (typeof Image === 'undefined') {
-      return Promise.resolve();
-    }
     const resolve = path => new URL(`../${path}`, import.meta.url).href;
     const assets = [
       { key: 'player_0', src: resolve('public/assets/sprites/principessa/princess_0.png') },
@@ -39,6 +41,9 @@ export class Renderer {
       { key: 'knight_2', src: resolve('public/assets/sprites/cavaliere_nero/knight_2.png') },
       { key: 'wall', src: resolve('sprites/projectiles/wall/00.png') },
       { key: 'shield', src: resolve('public/assets/sprites/shield.png') },
+      { key: 'jump', src: JUMP_SOUND, type: 'audio' },
+      { key: 'coin', src: COIN_SOUND, type: 'audio' },
+      { key: 'shield_hit', src: SHIELD_SOUND, type: 'audio' },
     ];
     return this.assets.loadAll(assets).then(() => {
       this.playerSprites = {
@@ -64,7 +69,21 @@ export class Renderer {
       ];
       this.wallSprite = this.assets.get('wall');
       this.shieldSprite = this.assets.get('shield');
+      this.sounds.jump = this.assets.get('jump');
+      this.sounds.coin = this.assets.get('coin');
+      this.sounds.shield = this.assets.get('shield_hit');
+      Object.values(this.sounds).forEach(s => {
+        if (s) s.volume = 0.5;
+      });
     });
+  }
+
+  playSound(key) {
+    const audio = this.sounds[key];
+    if (audio && typeof audio.play === 'function') {
+      audio.currentTime = 0;
+      audio.play();
+    }
   }
 
   withContext(drawFn) {


### PR DESCRIPTION
## Summary
- extend asset manager to load audio assets alongside images
- preload jump, coin and shield sounds and play them during gameplay events
- add unit tests for audio initialization and playback
- inline audio assets as base64 data URIs to avoid binary files

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ace9fd22cc832cb221f3c927e26afc