### PR TITLE
feat: add enchanted level three

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ PrincessOnUnicorn is a side-scrolling runner inspired by the Chrome offline T‑
 ## Features
 - Medieval themed interface.
 - Start menu disappears once the game begins.
-- Two levels, including a boss fight against the Black Knight.
+- Three levels, including a boss fight against the Black Knight and an enchanted run through Unicornolandia.
 
 ## Play
 Open `index.html` in a modern browser. Press the spacebar or tap the screen to jump over obstacles. Reach **1000 points** to face the Black Knight.
@@ -17,6 +17,14 @@ index.html?level=2
 ```
 
 In Level 2 the Black Knight throws walls at you. Press the spacebar or tap again to activate a shield and keep tapping to maintain it. The shield now recharges 10% faster, and if a wall hits while the shield is active it shatters and the unicorn advances. When the knight runs out of space he flees and the princess wins.
+
+To explore the enchanted third level with mini cactus enemies, open:
+
+```
+index.html?level=3
+```
+
+In Level 3 the princess rides through Unicornolandia, jumping over rows of mischievous mini cactus.
 
 ## Development
 The project has no external dependencies; a recent Node.js installation is sufficient to run the tests and develop new features.

--- a/docs/WIKI.md
+++ b/docs/WIKI.md
@@ -16,6 +16,7 @@ Points increase with distance. Reach 1000 to encounter the Black Knight.
 ### Levels
 1. **Forest Run** – avoid obstacles and collect points.
 2. **Black Knight** – the knight hurls walls at the unicorn. Use the shield to break them. After several successful blocks the knight retreats.
+3. **Unicornolandia** – an enchanted path filled with mischievous mini cactus to leap over.
 
 ## Code Structure
 - `index.html` boots the game.

--- a/level3.test.js
+++ b/level3.test.js
@@ -1,0 +1,33 @@
+import test from 'node:test';
+import assert from 'node:assert';
+import { createStubGame } from './testHelpers.js';
+import { Level3 } from './src/levels/level3.js';
+
+const FRAME = 1 / 60;
+
+test('level 3 uses mini cactus obstacles', () => {
+  const game = createStubGame({ search: '?level=3', skipLevelUpdate: true });
+  const obstacle = game.level.createObstacle();
+  assert.strictEqual(obstacle.width, 0.2);
+  assert.strictEqual(obstacle.height, 0.4);
+});
+
+test('level 3 move speed slightly faster', () => {
+  const game = createStubGame({ search: '?level=3', skipLevelUpdate: true });
+  const level = game.level;
+  assert.strictEqual(level.getMoveSpeed(), game.speed + 0.2);
+});
+
+test('level 3 spawn interval is shorter', () => {
+  const interval = Level3.getInterval(() => 0);
+  assert.strictEqual(interval, 50 / 60);
+});
+
+test('level 3 spawns obstacle after interval', () => {
+  const game = createStubGame({ search: '?level=3' });
+  const level = game.level;
+  assert.strictEqual(level.obstacles.length, 0);
+  level.timer = level.interval;
+  level.update(FRAME);
+  assert.strictEqual(level.obstacles.length, 1);
+});

--- a/src/game.js
+++ b/src/game.js
@@ -2,6 +2,7 @@ import { Player } from './player.js';
 import { InputHandler } from './input.js';
 import { Level1 } from './levels/level1.js';
 import { Level2 } from './levels/level2.js';
+import { Level3 } from './levels/level3.js';
 import { Renderer } from './renderer.js';
 import { Overlay } from './overlay.js';
 import { INSTRUCTIONS_TEXT, STORY_TEXT } from './texts.js';
@@ -38,7 +39,8 @@ export class Game {
     this.worldHeight = WORLD_HEIGHT;
 
     this.params = new URLSearchParams(window.location.search);
-    this.levelNumber = this.params.get('level') === '2' ? 2 : 1;
+    const levelParam = parseInt(this.params.get('level'), 10);
+    this.levelNumber = [1, 2, 3].includes(levelParam) ? levelParam : 1;
 
     this.boundResize = this.throttle(() => this.resizeCanvas(), RESIZE_THROTTLE_MS);
     window.addEventListener('resize', this.boundResize);
@@ -74,7 +76,13 @@ export class Game {
   initializeLevel() {
     const startX = 0.5 + 0.8 / 2;
     this.player = new Player(startX, this.groundY, this.scale);
-    this.level = this.levelNumber === 1 ? new Level1(this, this.random) : new Level2(this, this.random);
+    if (this.levelNumber === 1) {
+      this.level = new Level1(this, this.random);
+    } else if (this.levelNumber === 2) {
+      this.level = new Level2(this, this.random);
+    } else {
+      this.level = new Level3(this, this.random);
+    }
     if (typeof this.level.setScale === 'function') {
       this.level.setScale(this.scale);
     }

--- a/src/levels/level3.js
+++ b/src/levels/level3.js
@@ -1,0 +1,31 @@
+import { BaseLevel } from './baseLevel.js';
+import { Obstacle } from '../obstacle.js';
+
+// Level 3 - Unicornolandia with mini cactus obstacles
+export class Level3 extends BaseLevel {
+  static getInterval(random) {
+    // Faster pace similar to classic platformers
+    return (50 + random() * 40) / 60;
+  }
+
+  getMoveSpeed() {
+    // Slightly increase speed to keep the challenge
+    return this.game.speed + 0.2;
+  }
+
+  createObstacle() {
+    // Mini cactus obstacles
+    const width = 0.2;
+    const height = 0.4;
+    const obstacle = new Obstacle(
+      this.game.worldWidth + width / 2,
+      this.game.groundY - height / 2,
+      width,
+      height
+    );
+    obstacle.setScale(this.game.scale);
+    obstacle.imageIndex = Math.floor(this.random() * 3);
+    obstacle.coinAwarded = false;
+    return obstacle;
+  }
+}

--- a/src/texts.js
+++ b/src/texts.js
@@ -1,9 +1,11 @@
 export const INSTRUCTIONS_TEXT = {
   1: 'Salta gli ostacoli premendo la barra spaziatrice o toccando lo schermo.',
-  2: 'Attiva lo scudo per rompere i muri del Cavaliere Nero premendo la barra spaziatrice o toccando lo schermo.'
+  2: 'Attiva lo scudo per rompere i muri del Cavaliere Nero premendo la barra spaziatrice o toccando lo schermo.',
+  3: 'Affronta il sentiero incantato di Unicornolandia evitando i minicactus con la barra spaziatrice o un tocco sullo schermo.'
 };
 
 export const STORY_TEXT = {
   1: 'La principessa supera la foresta e si avvicina al castello del Cavaliere Nero.',
-  2: 'Il Cavaliere Nero fugge e il regno è salvo!'
+  2: 'Il Cavaliere Nero fugge e il regno è salvo!',
+  3: 'La principessa salva Unicornolandia e il regno è in festa!'
 };


### PR DESCRIPTION
## Summary
- add third level "Unicornolandia" with mini cactus obstacles
- enable selecting level 3 via URL parameter and document new world
- cover level 3 behaviour with dedicated tests

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68af63c5e550832caf40eba532436805