### PR TITLE
Allow selecting any level via query parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,8 @@ index.html?level=3
 
 In Level 3 the princess rides through Unicornolandia, jumping over rows of mischievous mini cactus.
 
+You can jump to any available level by adjusting the `level` query parameter, for example `index.html?level=4` once a fourth level is added.
+
 ## Development
 The project has no external dependencies; a recent Node.js installation is sufficient to run the tests and develop new features.
 

--- a/game.test.js
+++ b/game.test.js
@@ -18,6 +18,11 @@ test('advances to level 2 after reaching threshold points', () => {
   assert.ok(game.level instanceof Level2);
 });
 
+test('defaults to level 1 for unknown level param', () => {
+  const game = createStubGame({ search: '?level=99', skipLevelUpdate: true });
+  assert.strictEqual(game.levelNumber, 1);
+});
+
 test('resets when action is triggered after game over', () => {
   const game = createStubGame({ skipLevelUpdate: true });
   let resetCalled = false;

--- a/src/game.js
+++ b/src/game.js
@@ -15,6 +15,8 @@ import {
   WORLD_HEIGHT,
 } from './config.js';
 
+const LEVELS = [Level1, Level2, Level3];
+
 export class Game {
   constructor(canvas, randomFn = Math.random) {
     this.canvas = canvas;
@@ -40,7 +42,7 @@ export class Game {
 
     this.params = new URLSearchParams(window.location.search);
     const levelParam = parseInt(this.params.get('level'), 10);
-    this.levelNumber = [1, 2, 3].includes(levelParam) ? levelParam : 1;
+    this.levelNumber = levelParam >= 1 && levelParam <= LEVELS.length ? levelParam : 1;
 
     this.boundResize = this.throttle(() => this.resizeCanvas(), RESIZE_THROTTLE_MS);
     window.addEventListener('resize', this.boundResize);
@@ -76,13 +78,8 @@ export class Game {
   initializeLevel() {
     const startX = 0.5 + 0.8 / 2;
     this.player = new Player(startX, this.groundY, this.scale);
-    if (this.levelNumber === 1) {
-      this.level = new Level1(this, this.random);
-    } else if (this.levelNumber === 2) {
-      this.level = new Level2(this, this.random);
-    } else {
-      this.level = new Level3(this, this.random);
-    }
+    const LevelClass = LEVELS[this.levelNumber - 1];
+    this.level = new LevelClass(this, this.random);
     if (typeof this.level.setScale === 'function') {
       this.level.setScale(this.scale);
     }


### PR DESCRIPTION
## Summary
- select starting level via `?level` parameter for any number of defined levels
- document generic `level` query parameter usage
- test unknown `level` values default to level 1

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68af65c88600832c92ca9845fb07322f