### PR TITLE
ensure runtime env.js persists in Pages build

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,0 +1,51 @@
+name: Deploy Pages
+
+on:
+  push:
+    branches: [ main ]
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Stage static files
+        run: |
+          mkdir -p dist
+          cp index.html dist/
+          cp main.js dist/
+          cp style.css dist/
+          cp custom-elements-patch.js dist/
+          cp -r assets dist/assets
+          cp -r sprites dist/sprites
+
+      - name: Create runtime env.js
+        env:
+          SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
+          SUPABASE_ANON_KEY: ${{ secrets.SUPABASE_ANON_KEY }}
+        run: |
+          WS_URL="${SUPABASE_URL/https/wss}"
+          cat <<EOF2 > dist/env.js
+          window.__env = {
+            SUPABASE_URL: '${SUPABASE_URL}',
+            SUPABASE_ANON_KEY: '${SUPABASE_ANON_KEY}',
+            WS_URL: '${WS_URL}'
+          };
+          EOF2
+
+      - name: Sanity check env.js
+        run: |
+          echo '=== ENV.JS ==='
+          cat dist/env.js | sed -E "s/('[^']{4})[^']*'/\1***'/g"
+
+      - name: Debug dist/env.js
+        run: |
+          echo '=== ENV.JS FINAL ==='
+          cat dist/env.js | sed -E "s/('[^']{4})[^']*'/\1***'/g"
+
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v2
+        with:
+          path: dist


### PR DESCRIPTION
## Summary
- avoid copying repo env.js into dist
- generate runtime env.js from secrets and check contents
- upload Pages artifact after verifying env.js

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68af667df060832c9f1eaecba692570f