### PR TITLE
Add bidirectional movement controls

### DIFF
--- a/game.test.js
+++ b/game.test.js
@@ -94,10 +94,10 @@ test('toggles pause when pause key is pressed', () => {
     origHide();
   };
   game.gamePaused = false;
-  game.input.keyListener({ code: 'KeyP', repeat: false });
+  game.input.keydownListener({ code: 'KeyP', repeat: false });
   assert.ok(game.gamePaused);
   assert.ok(showed);
-  game.input.keyListener({ code: 'KeyP', repeat: false });
+  game.input.keydownListener({ code: 'KeyP', repeat: false });
   assert.ok(!game.gamePaused);
   assert.ok(hid);
 });

--- a/input.test.js
+++ b/input.test.js
@@ -16,12 +16,13 @@ test('attaches listeners with passive option by default', () => {
     },
     removeEventListener: () => {},
   };
-  const handler = new InputHandler({}, { pointerCallback: () => {} });
-  handler.attach();
-  assert.deepStrictEqual(calls, [
-    { target: 'document', type: 'keydown', options: { passive: true } },
-    { target: 'window', type: 'pointerdown', options: { passive: true } },
-  ]);
+  const handler = new InputHandler({}, {}, { pointerCallback: () => {} });
+    handler.attach();
+    assert.deepStrictEqual(calls, [
+      { target: 'document', type: 'keydown', options: { passive: true } },
+      { target: 'document', type: 'keyup', options: { passive: true } },
+      { target: 'window', type: 'pointerdown', options: { passive: true } },
+    ]);
 });
 
 test('supports dedicated callbacks for keys', () => {
@@ -30,10 +31,10 @@ test('supports dedicated callbacks for keys', () => {
   const handler = new InputHandler({
     KeyA: () => a++,
     KeyB: () => b++,
-  });
-  handler.keyListener({ code: 'KeyA', repeat: false });
-  handler.keyListener({ code: 'KeyB', repeat: false });
-  handler.keyListener({ code: 'Space', repeat: false });
+    });
+    handler.keydownListener({ code: 'KeyA', repeat: false });
+    handler.keydownListener({ code: 'KeyB', repeat: false });
+    handler.keydownListener({ code: 'Space', repeat: false });
   assert.strictEqual(a, 1);
   assert.strictEqual(b, 1);
 });

--- a/src/game.js
+++ b/src/game.js
@@ -55,14 +55,20 @@ export class Game {
 
     this.renderer = new Renderer(this);
 
-    const keyMap = {
-      Space: () => this.handleInput('Space'),
-      KeyP: () => this.handleInput('KeyP'),
-      Escape: () => this.handleInput('Escape'),
-    };
-    this.input = new InputHandler(keyMap, {
-      pointerCallback: () => this.handleInput('Space'),
-    });
+    const keydownMap = {
+        Space: () => this.handleInput('Space', 'down'),
+        KeyP: () => this.handleInput('KeyP', 'down'),
+        Escape: () => this.handleInput('Escape', 'down'),
+        ArrowRight: () => this.handleInput('ArrowRight', 'down'),
+        ArrowLeft: () => this.handleInput('ArrowLeft', 'down'),
+      };
+      const keyupMap = {
+        ArrowRight: () => this.handleInput('ArrowRight', 'up'),
+        ArrowLeft: () => this.handleInput('ArrowLeft', 'up'),
+      };
+      this.input = new InputHandler(keydownMap, keyupMap, {
+        pointerCallback: () => this.handleInput('Space', 'down'),
+      });
     this.input.attach();
 
     this.renderer
@@ -78,6 +84,7 @@ export class Game {
   initializeLevel() {
     const startX = 0.5 + 0.8 / 2;
     this.player = new Player(startX, this.groundY, this.scale);
+    this.player.worldWidth = this.worldWidth;
     const LevelClass = LEVELS[this.levelNumber - 1];
     this.level = new LevelClass(this, this.random);
     if (typeof this.level.setScale === 'function') {
@@ -154,18 +161,29 @@ export class Game {
     }
   }
 
-  handleInput(code = 'Space') {
+  handleInput(code = 'Space', type = 'down') {
     if (this.gameOver) {
       this.reset();
       return;
     }
 
-    if (code === 'KeyP' || code === 'Escape') {
+    if (type === 'down' && (code === 'KeyP' || code === 'Escape')) {
       this.togglePause();
       return;
     }
 
     if (this.gamePaused) return;
+
+    if (code === 'ArrowRight') {
+      if (type === 'down') this.player.moveRight();
+      else this.player.stopHorizontal();
+      return;
+    }
+    if (code === 'ArrowLeft') {
+      if (type === 'down') this.player.moveLeft();
+      else this.player.stopHorizontal();
+      return;
+    }
 
     if (this.levelNumber === 1) {
       this.player.jump();

--- a/src/input.js
+++ b/src/input.js
@@ -1,16 +1,23 @@
 export class InputHandler {
   constructor(
-    keyMap = {},
+    keydownMap = {},
+    keyupMap = {},
     { pointerEvent = 'pointerdown', pointerCallback, passive = true } = {},
   ) {
-    this.keyMap = keyMap;
+    this.keydownMap = keydownMap;
+    this.keyupMap = keyupMap;
     this.pointerEvent = pointerEvent;
     this.pointerCallback = pointerCallback;
     this.eventOptions = passive ? { passive: true } : undefined;
 
-    this.keyListener = (e) => {
-      const cb = this.keyMap[e.code];
+    this.keydownListener = (e) => {
+      const cb = this.keydownMap[e.code];
       if (cb && !e.repeat) cb();
+    };
+
+    this.keyupListener = (e) => {
+      const cb = this.keyupMap[e.code];
+      if (cb) cb();
     };
 
     this.pointerListener = () => {
@@ -19,13 +26,15 @@ export class InputHandler {
   }
 
   attach() {
-    document.addEventListener('keydown', this.keyListener, this.eventOptions);
+    document.addEventListener('keydown', this.keydownListener, this.eventOptions);
+    document.addEventListener('keyup', this.keyupListener, this.eventOptions);
     if (this.pointerEvent)
       window.addEventListener(this.pointerEvent, this.pointerListener, this.eventOptions);
   }
 
   detach() {
-    document.removeEventListener('keydown', this.keyListener, this.eventOptions);
+    document.removeEventListener('keydown', this.keydownListener, this.eventOptions);
+    document.removeEventListener('keyup', this.keyupListener, this.eventOptions);
     if (this.pointerEvent)
       window.removeEventListener(
         this.pointerEvent,

--- a/src/player.js
+++ b/src/player.js
@@ -16,6 +16,9 @@ export class Player {
     this.y = groundY - this.height / 2;
     this.spriteScale = scale;
     this.vy = 0;
+    this.vx = 0;
+    this.moveSpeed = 3;
+    this.worldWidth = 0; // to be set by game
     this.jumping = false;
     this.shieldActive = false;
     this.shieldTimer = 0;
@@ -36,6 +39,12 @@ export class Player {
       this.vy = 0;
       this.jumping = false;
     }
+    this.x += this.vx * delta;
+    if (this.worldWidth) {
+      const half = this.width / 2;
+      if (this.x < half) this.x = half;
+      if (this.x > this.worldWidth - half) this.x = this.worldWidth - half;
+    }
     if (this.shieldTimer > 0) {
       this.shieldTimer -= delta;
       if (this.shieldTimer <= 0) this.shieldActive = false;
@@ -51,6 +60,18 @@ export class Player {
       this.vy = JUMP_VELOCITY;
       this.jumping = true;
     }
+  }
+
+  moveLeft() {
+    this.vx = -this.moveSpeed;
+  }
+
+  moveRight() {
+    this.vx = this.moveSpeed;
+  }
+
+  stopHorizontal() {
+    this.vx = 0;
   }
 
   activateShield(


### PR DESCRIPTION
## Summary
- Support separate keydown/keyup callbacks in input handler
- Add horizontal movement to player and wire arrow keys to move left/right
- Update tests for new input handling

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68af6824e28c832caef4c48acc27ab25