### PR TITLE
Transform level 3 into scripted cactus platform stage

### DIFF
--- a/level3.test.js
+++ b/level3.test.js
@@ -1,33 +1,49 @@
 import test from 'node:test';
 import assert from 'node:assert';
 import { createStubGame } from './testHelpers.js';
-import { Level3 } from './src/levels/level3.js';
 
 const FRAME = 1 / 60;
 
+// Ensure obstacles are mini cactus
+// and have the expected dimensions
+// and type flag for rendering.
 test('level 3 uses mini cactus obstacles', () => {
   const game = createStubGame({ search: '?level=3', skipLevelUpdate: true });
   const obstacle = game.level.createObstacle();
   assert.strictEqual(obstacle.width, 0.2);
   assert.strictEqual(obstacle.height, 0.4);
+  assert.strictEqual(obstacle.type, 'cactus');
 });
 
-test('level 3 move speed slightly faster', () => {
-  const game = createStubGame({ search: '?level=3', skipLevelUpdate: true });
-  const level = game.level;
-  assert.strictEqual(level.getMoveSpeed(), game.speed + 0.2);
-});
-
-test('level 3 spawn interval is shorter', () => {
-  const interval = Level3.getInterval(() => 0);
-  assert.strictEqual(interval, 50 / 60);
-});
-
-test('level 3 spawns obstacle after interval', () => {
+// Distance travelled should increase according to the
+// move speed so that layout markers are hit at the
+// expected times.
+test('level 3 advances using move speed', () => {
   const game = createStubGame({ search: '?level=3' });
   const level = game.level;
+  level.update(1); // one second
+  assert.strictEqual(level.distance, level.getMoveSpeed());
+});
+
+// Obstacles spawn only after travelling the layout distance.
+test('level 3 spawns obstacles based on layout', () => {
+  const game = createStubGame({ search: '?level=3' });
+  const level = game.level;
+  for (let i = 0; i < 100; i++) level.update(FRAME);
   assert.strictEqual(level.obstacles.length, 0);
-  level.timer = level.interval;
-  level.update(FRAME);
-  assert.strictEqual(level.obstacles.length, 1);
+  for (let i = 0; i < 100; i++) level.update(FRAME);
+  assert.ok(level.obstacles.length > 0);
+});
+
+// After travelling the entire level and clearing obstacles
+// the level should signal completion.
+test('level 3 completes after level length', () => {
+  const game = createStubGame({ search: '?level=3' });
+  const level = game.level;
+  let steps = 0;
+  while (!game.win && steps < 5000) {
+    level.update(FRAME);
+    steps++;
+  }
+  assert.ok(game.win);
 });

--- a/src/levels/level3.js
+++ b/src/levels/level3.js
@@ -1,11 +1,30 @@
 import { BaseLevel } from './baseLevel.js';
 import { Obstacle } from '../obstacle.js';
 
-// Level 3 - Unicornolandia with mini cactus obstacles
+// Predetermined positions (in world units travelled) where
+// obstacles should appear. This acts as a very small tile map
+// describing the rhythm of the level.
+const LAYOUT = [5, 9, 13, 17, 22];
+
+// Total length of the level in world units. Once the player has
+// scrolled this far and all obstacles have been cleared the level
+// is considered complete.
+const LEVEL_LENGTH = 26;
+
+// Level 3 - Unicornolandia as a scripted platform section
 export class Level3 extends BaseLevel {
-  static getInterval(random) {
-    // Faster pace similar to classic platformers
-    return (50 + random() * 40) / 60;
+  constructor(game, random = Math.random) {
+    super(game, random);
+    this.layout = LAYOUT;
+    this.distance = 0; // total distance travelled in world units
+    this.nextIndex = 0; // next obstacle to spawn from layout
+    this.levelLength = LEVEL_LENGTH;
+  }
+
+  // Spawn interval from BaseLevel isn't used anymore but kept for
+  // compatibility with existing code paths.
+  static getInterval() {
+    return Infinity;
   }
 
   getMoveSpeed() {
@@ -14,7 +33,7 @@ export class Level3 extends BaseLevel {
   }
 
   createObstacle() {
-    // Mini cactus obstacles
+    // Mini cactus obstacles replacing mushrooms
     const width = 0.2;
     const height = 0.4;
     const obstacle = new Obstacle(
@@ -23,9 +42,44 @@ export class Level3 extends BaseLevel {
       width,
       height
     );
+    obstacle.type = 'cactus';
     obstacle.setScale(this.game.scale);
-    obstacle.imageIndex = Math.floor(this.random() * 3);
+    obstacle.imageIndex = Math.floor(this.random() * 2);
     obstacle.coinAwarded = false;
     return obstacle;
   }
+
+  update(delta) {
+    const move = this.getMoveSpeed() * delta;
+    this.distance += move;
+
+    // Spawn obstacles when reaching the next layout marker
+    while (
+      this.nextIndex < this.layout.length &&
+      this.distance >= this.layout[this.nextIndex]
+    ) {
+      this.obstacles.push(this.createObstacle());
+      this.nextIndex++;
+    }
+
+    // Move existing obstacles and handle collisions
+    this.obstacles.forEach(o => o.update(move));
+    this.obstacles = this.obstacles.filter(o => {
+      const obstacleRight = o.x + o.width / 2;
+      const playerLeft = this.game.player.x - this.game.player.width / 2;
+      if (obstacleRight < playerLeft) {
+        this.onObstaclePassed(o);
+        return false;
+      }
+      return this.handleCollision(o);
+    });
+
+    // Level complete when travelled the full length and cleared obstacles
+    if (this.distance >= this.levelLength && this.obstacles.length === 0) {
+      this.game.gameOver = true;
+      this.game.win = true;
+    }
+  }
 }
+
+export { LAYOUT as LEVEL3_LAYOUT };

--- a/src/renderer.js
+++ b/src/renderer.js
@@ -30,9 +30,9 @@ export class Renderer {
   preload() {
     const resolve = path => new URL(`../${path}`, import.meta.url).href;
     const assets = [
-      { key: 'player_0', src: resolve('public/assets/sprites/principessa/princess_0.png') },
-      { key: 'player_1', src: resolve('public/assets/sprites/principessa/princess_1.png') },
-      { key: 'player_2', src: resolve('public/assets/sprites/principessa/princess_2.png') },
+      { key: 'player_0', src: resolve('public/assets/sprites/princess_0.png') },
+      { key: 'player_1', src: resolve('public/assets/sprites/princess_1.png') },
+      { key: 'player_2', src: resolve('public/assets/sprites/princess_2.png') },
       { key: 'tree_0', src: resolve('sprites/obstacles/trees/00.png') },
       { key: 'tree_1', src: resolve('sprites/obstacles/trees/01.png') },
       { key: 'tree_2', src: resolve('sprites/obstacles/trees/02.png') },
@@ -189,9 +189,14 @@ export class Renderer {
         const left = o.x * scale - w / 2;
         const bottom = (o.y + o.height / 2) * scale;
         const top = bottom - h;
-        if (this.treeSprites) {
-          const img = this.treeSprites[(o.imageIndex ?? 0) % this.treeSprites.length];
+        const sprites = o.type === 'tree' ? this.treeSprites : null;
+        if (sprites) {
+          const img = sprites[(o.imageIndex ?? 0) % sprites.length];
           ctx.drawImage(img, left, top, w, h);
+        } else if (o.type === 'cactus') {
+          ctx.fillStyle = 'green';
+          ctx.fillRect(left + w * 0.4, top, w * 0.2, h);
+          ctx.fillRect(left, top + h * 0.4, w, h * 0.2);
         } else {
           ctx.fillStyle = 'green';
           ctx.fillRect(left, top, w, h);


### PR DESCRIPTION
## Summary
- Convert level 3 from endless runner to scripted platform layout using a small tile map and completion logic
- Render princess player sprite and draw placeholder cactus obstacles instead of binary sprites
- Add tests for cactus obstacles, deterministic layout spawning, distance tracking and level completion

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68af70aa5664832cae1acf867b827c62