### PR TITLE
docs: add demo and clarify Mario differences

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,12 @@ PrincessOnUnicorn is a side-scrolling runner inspired by the Chrome offline T‑
 - Start menu disappears once the game begins.
 - Three levels, including a boss fight against the Black Knight and an enchanted run through Unicornolandia.
 
+## Differences from Mario
+- Endless runner rather than a traditional platformer.
+- One-button jumping and shielding instead of complex moves.
+- Medieval setting with a unicorn mount replaces the plumber in the Mushroom Kingdom.
+- Boss battle against the Black Knight instead of Bowser.
+
 ## Play
 Open `index.html` in a modern browser. Press the spacebar or tap the screen to jump over obstacles. Reach **1000 points** to face the Black Knight.
 
@@ -27,6 +33,9 @@ index.html?level=3
 In Level 3 the princess rides through Unicornolandia, jumping over rows of mischievous mini cactus.
 
 You can jump to any available level by adjusting the `level` query parameter, for example `index.html?level=4` once a fourth level is added.
+
+## Demo
+![Princess on Unicorn demo](public/assets/sprites/princess_0.png)
 
 ## Development
 The project has no external dependencies; a recent Node.js installation is sufficient to run the tests and develop new features.

--- a/demo.html
+++ b/demo.html
@@ -2,7 +2,7 @@
 <html lang="en">
 <head>
   <meta charset="UTF-8" />
-  <title>Sprite Demo</title>
+  <title>PrincessOnUnicorn Demo</title>
   <style>
     body { margin: 0; background: #222; display: flex; justify-content: center; align-items: center; height: 100vh; }
     canvas { background: #9bd4ff; }
@@ -10,6 +10,8 @@
 </head>
 <body>
   <canvas id="demo" width="800" height="200"></canvas>
+  <p>Preview del runner con principessa sull'unicorno, distinto da Mario per il ritmo incessante e l'ambientazione fiabesca.</p>
+  <img src="public/assets/sprites/princess_0.png" alt="Demo Princess on Unicorn" width="512" />
   <script type="module" src="src/demo/demo.js"></script>
 </body>
 </html>

--- a/docs/WIKI.md
+++ b/docs/WIKI.md
@@ -18,6 +18,14 @@ Points increase with distance. Reach 1000 to encounter the Black Knight.
 2. **Black Knight** – the knight hurls walls at the unicorn. Use the shield to break them. After several successful blocks the knight retreats.
 3. **Unicornolandia** – an enchanted path filled with mischievous mini cactus to leap over.
 
+## Differences from Mario
+- Continuous runner; no brick-breaking or backtracking.
+- Single jump/shield control instead of multiple power-ups.
+- Medieval fantasy theme replaces the plumber's Mushroom Kingdom.
+
+## Demo
+![Princess on Unicorn demo](../public/assets/sprites/princess_0.png)
+
 ## Code Structure
 - `index.html` boots the game.
 - `main.js` handles the game loop and level logic.

--- a/index.html
+++ b/index.html
@@ -3,6 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="description" content="Runner con principessa e unicorno, diverso da Mario per controlli semplici e ambientazione medievale." />
   <title>Principessa sull'Unicorno Runner</title>
   <link href="https://fonts.googleapis.com/css2?family=Bellefair&family=MedievalSharp&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="style.css">


### PR DESCRIPTION
## Summary
- document key differences from Mario and include demo screenshot
- link demo screenshot in documentation and sample pages
- reference existing asset instead of binary screenshot

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68af7354d158832c99d426c299b5085c