### PR TITLE
Expand level coverage and collision tests

### DIFF
--- a/collision.test.js
+++ b/collision.test.js
@@ -44,3 +44,11 @@ test('detects collision while jumping into obstacle', () => {
   const obstacle = createEntity(0.6, groundY, 0.32, 0.48);
   assert.strictEqual(isColliding(unicorn, obstacle), true);
 });
+
+test('extended width collider detects earlier collision', () => {
+  const unicorn = createEntity(0.5, groundY, 0.8, 0.8);
+  const shielded = { ...unicorn, width: unicorn.width + 0.4 }; // simulate shield range
+  const obstacle = createEntity(1.45, groundY, 0.32, 0.64);
+  assert.strictEqual(isColliding(unicorn, obstacle), false);
+  assert.strictEqual(isColliding(shielded, obstacle), true);
+});

--- a/docs/manual-testing.md
+++ b/docs/manual-testing.md
@@ -1,0 +1,19 @@
+# Manual Testing Scenarios
+
+## Level 1: Enchanted Forest
+1. Open the game with `?level=1` in the URL.
+2. Confirm tree obstacles appear at varying intervals.
+3. Jump over a tree to ensure collision does not occur.
+4. Allow a tree to pass completely behind the player and verify a coin is awarded.
+
+## Level 2: Knight's Gauntlet
+1. Open the game with `?level=2`.
+2. Observe the knight boss on the right edge and walls thrown toward the player.
+3. Activate the shield (space bar or click) before a wall arrives and ensure the wall is destroyed and a coin appears.
+4. Let the shield expire and miss a wall to confirm the game ends.
+
+## Level 3: Unicornolandia
+1. Open the game with `?level=3`.
+2. Verify small cactus obstacles spawn according to the level layout.
+3. Traverse the level without colliding to reach the end and see the victory overlay.
+4. Ensure coins are collected when cacti are successfully avoided.

--- a/game.test.js
+++ b/game.test.js
@@ -3,6 +3,7 @@ import assert from 'node:assert';
 import { createStubGame } from './testHelpers.js';
 import { Game } from './src/game.js';
 import { Level2 } from './src/levels/level2.js';
+import { Level3 } from './src/levels/level3.js';
 import { LEVEL_UP_SCORE } from './src/config.js';
 
 const FRAME = 1 / 60;
@@ -21,6 +22,15 @@ test('advances to level 2 after reaching threshold points', () => {
 test('defaults to level 1 for unknown level param', () => {
   const game = createStubGame({ search: '?level=99', skipLevelUpdate: true });
   assert.strictEqual(game.levelNumber, 1);
+});
+
+test('loads levels from query parameter', () => {
+  const game2 = createStubGame({ search: '?level=2', skipLevelUpdate: true });
+  assert.strictEqual(game2.levelNumber, 2);
+  assert.ok(game2.level instanceof Level2);
+  const game3 = createStubGame({ search: '?level=3', skipLevelUpdate: true });
+  assert.strictEqual(game3.levelNumber, 3);
+  assert.ok(game3.level instanceof Level3);
 });
 
 test('resets when action is triggered after game over', () => {

--- a/level1.test.js
+++ b/level1.test.js
@@ -1,0 +1,21 @@
+import test from 'node:test';
+import assert from 'node:assert';
+import { createStubGame } from './testHelpers.js';
+
+test('level 1 obstacles have tree dimensions', () => {
+  const game = createStubGame({ search: '?level=1' });
+  const obstacle = game.level.createObstacle();
+  assert.strictEqual(obstacle.width, 0.32);
+  assert.strictEqual(obstacle.height, 0.64);
+});
+
+test('level 1 awards coin when obstacle passes', () => {
+  const game = createStubGame({ search: '?level=1' });
+  const level = game.level;
+  const obstacle = level.createObstacle();
+  obstacle.x = game.player.x - game.player.width - obstacle.width;
+  level.obstacles.push(obstacle);
+  const before = game.coins;
+  level.update(0);
+  assert.strictEqual(game.coins, before + 1);
+});


### PR DESCRIPTION
## Summary
- add level selection tests to ensure URL parameters load levels 2 and 3
- verify tree obstacles and coin awards in new Level 1 suite
- cover shield-style collisions and document manual scenarios for each level

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68af755b56b0832ca3cd0e22bc94f73b