### PR TITLE
Enable jumping in level 3

### DIFF
--- a/level3.test.js
+++ b/level3.test.js
@@ -47,3 +47,12 @@ test('level 3 completes after level length', () => {
   }
   assert.ok(game.win);
 });
+
+// Level 3 uses jump instead of shield when pressing the action button
+test('level 3 maps space to jump', () => {
+  const game = createStubGame({ search: '?level=3', skipLevelUpdate: true });
+  const player = game.player;
+  game.handleInput();
+  assert.strictEqual(player.jumping, true);
+  assert.strictEqual(player.shieldActive, false);
+});

--- a/src/game.js
+++ b/src/game.js
@@ -185,7 +185,7 @@ export class Game {
       return;
     }
 
-    if (this.levelNumber === 1) {
+    if (this.levelNumber === 1 || this.levelNumber === 3) {
       this.player.jump();
       this.renderer.playSound('jump');
     } else {


### PR DESCRIPTION
## Summary
- Allow the princess to jump with the space bar in level 3 instead of activating the shield
- Add test verifying space triggers jump and shield stays inactive

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68af77a99bcc832c9572461e86f65e59