### PR TITLE
Add moving cacti and idle princess animation

### DIFF
--- a/level3.test.js
+++ b/level3.test.js
@@ -13,6 +13,10 @@ test('level 3 uses mini cactus obstacles', () => {
   assert.strictEqual(obstacle.width, 0.2);
   assert.strictEqual(obstacle.height, 0.4);
   assert.strictEqual(obstacle.type, 'cactus');
+  assert.ok(obstacle.vx < 0);
+  const start = obstacle.x;
+  obstacle.update(0, 1);
+  assert.ok(obstacle.x < start);
 });
 
 // Distance travelled should increase according to the

--- a/src/levels/baseLevel.js
+++ b/src/levels/baseLevel.js
@@ -62,7 +62,7 @@ export class BaseLevel {
     }
     const move = this.getMoveSpeed() * delta;
     this.obstacles.forEach(o => {
-      o.update(move);
+      o.update(move, delta);
     });
     this.obstacles = this.obstacles.filter(o => {
       const obstacleRight = o.x + o.width / 2;

--- a/src/levels/level3.js
+++ b/src/levels/level3.js
@@ -46,6 +46,8 @@ export class Level3 extends BaseLevel {
     obstacle.setScale(this.game.scale);
     obstacle.imageIndex = Math.floor(this.random() * 2);
     obstacle.coinAwarded = false;
+    // Give the cactus its own movement so it walks across the ground.
+    obstacle.vx = -0.5;
     return obstacle;
   }
 
@@ -63,7 +65,7 @@ export class Level3 extends BaseLevel {
     }
 
     // Move existing obstacles and handle collisions
-    this.obstacles.forEach(o => o.update(move));
+    this.obstacles.forEach(o => o.update(move, delta));
     this.obstacles = this.obstacles.filter(o => {
       const obstacleRight = o.x + o.width / 2;
       const playerLeft = this.game.player.x - this.game.player.width / 2;

--- a/src/obstacle.js
+++ b/src/obstacle.js
@@ -11,13 +11,16 @@ export class Obstacle {
     this.baseWidth = width;
     this.baseHeight = height;
     this.spriteScale = 1;
+    // Horizontal velocity in world units per second.
+    this.vx = 0;
   }
 
   setScale(scale) {
     this.spriteScale = scale;
   }
 
-  update(speed) {
+  update(speed, delta = 0) {
     this.x -= speed;
+    this.x += this.vx * delta;
   }
 }

--- a/src/renderer.js
+++ b/src/renderer.js
@@ -168,7 +168,10 @@ export class Renderer {
         const delta = (now - this.lastSpriteTime) / 1000;
         this.lastSpriteTime = now;
         this.playerFrameTimer += delta;
-        const anim = this.game.gamePaused || this.game.gameOver ? 'idle' : 'run';
+        const anim =
+          this.game.gamePaused ||
+          this.game.gameOver ||
+          u.vx === 0 ? 'idle' : 'run';
         const frames = this.playerSprites[anim];
         if (this.playerFrameTimer >= this.frameInterval) {
           this.playerFrameTimer = 0;


### PR DESCRIPTION
## Summary
- Keep princess idle when not being moved by the player
- Give Level 3 cactus obstacles their own horizontal movement
- Verify cactus behavior with updated tests

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68af7a4e46d4832cb468ca99fdd966cf