### PR TITLE
Restrict actions by level

### DIFF
--- a/level1.test.js
+++ b/level1.test.js
@@ -19,3 +19,20 @@ test('level 1 awards coin when obstacle passes', () => {
   level.update(0);
   assert.strictEqual(game.coins, before + 1);
 });
+
+test('level 1 maps space to jump only', () => {
+  const game = createStubGame({ search: '?level=1', skipLevelUpdate: true });
+  const player = game.player;
+  game.handleInput();
+  assert.strictEqual(player.jumping, true);
+  assert.strictEqual(player.shieldActive, false);
+});
+
+test('level 1 ignores horizontal movement', () => {
+  const game = createStubGame({ search: '?level=1', skipLevelUpdate: true });
+  const player = game.player;
+  const startX = player.x;
+  game.handleInput('ArrowRight', 'down');
+  player.update(0, game.groundY, 1);
+  assert.strictEqual(player.x, startX);
+});

--- a/level2.test.js
+++ b/level2.test.js
@@ -6,6 +6,23 @@ import { SHIELD_COOLDOWN } from './src/config.js';
 
 const FRAME = 1 / 60;
 
+test('level 2 maps space to shield only', () => {
+  const game = createStubGame({ search: '?level=2', skipLevelUpdate: true });
+  const player = game.player;
+  game.handleInput();
+  assert.strictEqual(player.shieldActive, true);
+  assert.strictEqual(player.jumping, false);
+});
+
+test('level 2 ignores horizontal movement', () => {
+  const game = createStubGame({ search: '?level=2', skipLevelUpdate: true });
+  const player = game.player;
+  const startX = player.x;
+  game.handleInput('ArrowLeft', 'down');
+  player.update(0, game.groundY, 1);
+  assert.strictEqual(player.x, startX);
+});
+
 test('player covers 80% of distance after destroying 15 walls', () => {
   const game = createStubGame({ skipLevelUpdate: true });
   const level = new Level2(game);

--- a/src/game.js
+++ b/src/game.js
@@ -175,11 +175,13 @@ export class Game {
     if (this.gamePaused) return;
 
     if (code === 'ArrowRight') {
+      if (this.levelNumber !== 3) return;
       if (type === 'down') this.player.moveRight();
       else this.player.stopHorizontal();
       return;
     }
     if (code === 'ArrowLeft') {
+      if (this.levelNumber !== 3) return;
       if (type === 'down') this.player.moveLeft();
       else this.player.stopHorizontal();
       return;


### PR DESCRIPTION
## Summary
- Ignore horizontal arrow key input in levels 1 and 2 so those stages focus on jump and shield, respectively
- Added tests verifying level-specific action mapping and disabled horizontal movement

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68af7f361088832c981a04a196a05d73