### PR TITLE
Refactor Level3 to tile map

### DIFF
--- a/level3.test.js
+++ b/level3.test.js
@@ -1,23 +1,20 @@
 import test from 'node:test';
 import assert from 'node:assert';
 import { createStubGame } from './testHelpers.js';
+import { LEVEL3_MAP } from './src/levels/level3.js';
 
 const FRAME = 1 / 60;
 
-// Ensure obstacles are mini cactus
-// and have the expected dimensions
-// and type flag for rendering.
-test('level 3 uses mini cactus obstacles', () => {
+// Ensure the tile map is loaded and entities are generated for each tile type.
+test('level 3 builds entities from tile map', () => {
   const game = createStubGame({ search: '?level=3', skipLevelUpdate: true });
-  const obstacle = game.level.createObstacle();
-  assert.strictEqual(obstacle.width, 0.2);
-  assert.strictEqual(obstacle.height, 0.4);
-  assert.strictEqual(obstacle.type, 'cactus');
+  const level = game.level;
+  assert.deepStrictEqual(level.map, LEVEL3_MAP);
+  assert.ok(level.platforms.length > 0);
+  assert.ok(level.pipes.length > 0);
 });
 
-// Distance travelled should increase according to the
-// move speed so that layout markers are hit at the
-// expected times.
+// Distance travelled should increase according to the move speed.
 test('level 3 advances using move speed', () => {
   const game = createStubGame({ search: '?level=3' });
   const level = game.level;
@@ -25,18 +22,7 @@ test('level 3 advances using move speed', () => {
   assert.strictEqual(level.distance, level.getMoveSpeed());
 });
 
-// Obstacles spawn only after travelling the layout distance.
-test('level 3 spawns obstacles based on layout', () => {
-  const game = createStubGame({ search: '?level=3' });
-  const level = game.level;
-  for (let i = 0; i < 100; i++) level.update(FRAME);
-  assert.strictEqual(level.obstacles.length, 0);
-  for (let i = 0; i < 100; i++) level.update(FRAME);
-  assert.ok(level.obstacles.length > 0);
-});
-
-// After travelling the entire level and clearing obstacles
-// the level should signal completion.
+// After travelling the entire level and clearing entities the level should end.
 test('level 3 completes after level length', () => {
   const game = createStubGame({ search: '?level=3' });
   const level = game.level;
@@ -56,3 +42,4 @@ test('level 3 maps space to jump', () => {
   assert.strictEqual(player.jumping, true);
   assert.strictEqual(player.shieldActive, false);
 });
+

--- a/src/levels/level3.js
+++ b/src/levels/level3.js
@@ -1,24 +1,63 @@
 import { BaseLevel } from './baseLevel.js';
 import { Obstacle } from '../obstacle.js';
+import { isColliding } from '../../collision.js';
 
-// Predetermined positions (in world units travelled) where
-// obstacles should appear. This acts as a very small tile map
-// describing the rhythm of the level.
-const LAYOUT = [5, 9, 13, 17, 22];
+// Tile identifiers inspired by tylerreichle/mario_js.
+// 0 = empty, 1 = ground, 2 = platform, 3 = pipe, 4 = block
+const TILE = {
+  EMPTY: 0,
+  GROUND: 1,
+  PLATFORM: 2,
+  PIPE: 3,
+  BLOCK: 4,
+};
 
-// Total length of the level in world units. Once the player has
-// scrolled this far and all obstacles have been cleared the level
-// is considered complete.
-const LEVEL_LENGTH = 26;
+// Two dimensional map describing the level layout. Each number
+// corresponds to a tile type defined above. The first row is the
+// ground and subsequent rows stack upwards.
+const MAP = [
+  // Ground row
+  [1, 1, 1, 1, 1, 1, 1, 1],
+  // Tiles one unit above the ground
+  [0, 2, 0, 3, 0, 2, 0, 0],
+  // Tiles two units above the ground
+  [0, 0, 0, 0, 4, 0, 0, 0],
+];
 
-// Level 3 - Unicornolandia as a scripted platform section
+class Platform extends Obstacle {
+  constructor(x, y, size) {
+    super(x, y, size, size);
+    this.type = 'platform';
+  }
+}
+
+class Pipe extends Obstacle {
+  constructor(x, groundY, size) {
+    // Pipes are two tiles tall and rest on the ground
+    super(x, groundY - size, size, size * 2);
+    this.type = 'pipe';
+  }
+}
+
+class Block extends Obstacle {
+  constructor(x, y, size) {
+    super(x, y, size, size);
+    this.type = 'block';
+  }
+}
+
+// Level 3 - Unicornolandia converted to a tile-based platform section
 export class Level3 extends BaseLevel {
   constructor(game, random = Math.random) {
     super(game, random);
-    this.layout = LAYOUT;
-    this.distance = 0; // total distance travelled in world units
-    this.nextIndex = 0; // next obstacle to spawn from layout
-    this.levelLength = LEVEL_LENGTH;
+    this.map = MAP;
+    this.tileSize = 1; // world units per tile
+    this.distance = 0;
+    this.levelLength = this.map[0].length * this.tileSize;
+    this.platforms = [];
+    this.pipes = [];
+    this.blocks = [];
+    this.generateFromMap();
   }
 
   // Spawn interval from BaseLevel isn't used anymore but kept for
@@ -32,54 +71,73 @@ export class Level3 extends BaseLevel {
     return this.game.speed + 0.2;
   }
 
-  createObstacle() {
-    // Mini cactus obstacles replacing mushrooms
-    const width = 0.2;
-    const height = 0.4;
-    const obstacle = new Obstacle(
-      this.game.worldWidth + width / 2,
-      this.game.groundY - height / 2,
-      width,
-      height
-    );
-    obstacle.type = 'cactus';
-    obstacle.setScale(this.game.scale);
-    obstacle.imageIndex = Math.floor(this.random() * 2);
-    obstacle.coinAwarded = false;
-    return obstacle;
+  generateFromMap() {
+    for (let row = 0; row < this.map.length; row++) {
+      const cols = this.map[row];
+      for (let col = 0; col < cols.length; col++) {
+        const tile = cols[col];
+        const x = this.game.worldWidth + col * this.tileSize + this.tileSize / 2;
+        const y = this.game.groundY - row * this.tileSize - this.tileSize / 2;
+        switch (tile) {
+          case TILE.PLATFORM:
+            this.platforms.push(new Platform(x, y, this.tileSize));
+            break;
+          case TILE.PIPE:
+            this.pipes.push(new Pipe(x, this.game.groundY, this.tileSize));
+            break;
+          case TILE.BLOCK:
+            this.blocks.push(new Block(x, y, this.tileSize));
+            break;
+          default:
+            break;
+        }
+      }
+    }
+    this.obstacles = [...this.platforms, ...this.pipes, ...this.blocks];
   }
 
   update(delta) {
     const move = this.getMoveSpeed() * delta;
     this.distance += move;
 
-    // Spawn obstacles when reaching the next layout marker
-    while (
-      this.nextIndex < this.layout.length &&
-      this.distance >= this.layout[this.nextIndex]
-    ) {
-      this.obstacles.push(this.createObstacle());
-      this.nextIndex++;
-    }
+    const moveArr = arr => arr.forEach(e => e.update(move));
+    moveArr(this.platforms);
+    moveArr(this.pipes);
+    moveArr(this.blocks);
 
-    // Move existing obstacles and handle collisions
-    this.obstacles.forEach(o => o.update(move));
-    this.obstacles = this.obstacles.filter(o => {
-      const obstacleRight = o.x + o.width / 2;
-      const playerLeft = this.game.player.x - this.game.player.width / 2;
-      if (obstacleRight < playerLeft) {
-        this.onObstaclePassed(o);
-        return false;
+    const player = this.game.player;
+    const collideArr = arr => {
+      for (const e of arr) {
+        if (isColliding(player, e)) {
+          this.game.gameOver = true;
+          return false;
+        }
       }
-      return this.handleCollision(o);
-    });
+      return true;
+    };
 
-    // Level complete when travelled the full length and cleared obstacles
+    if (!collideArr(this.platforms)) return;
+    if (!collideArr(this.pipes)) return;
+    if (!collideArr(this.blocks)) return;
+
+    const filterArr = arr => arr.filter(e => e.x + e.width / 2 > 0);
+    this.platforms = filterArr(this.platforms);
+    this.pipes = filterArr(this.pipes);
+    this.blocks = filterArr(this.blocks);
+    this.obstacles = [...this.platforms, ...this.pipes, ...this.blocks];
+
     if (this.distance >= this.levelLength && this.obstacles.length === 0) {
       this.game.gameOver = true;
       this.game.win = true;
     }
   }
+
+  setScale(scale) {
+    [...this.platforms, ...this.pipes, ...this.blocks].forEach(o =>
+      o.setScale(scale)
+    );
+  }
 }
 
-export { LAYOUT as LEVEL3_LAYOUT };
+export { MAP as LEVEL3_MAP, TILE };
+


### PR DESCRIPTION
## Summary
- Replace layout array with tile-based map and dedicated Platform, Pipe and Block entities
- Generate entities from map and refactor level update to handle tile scrolling and collisions
- Add tests for tile map, movement and level completion

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68af80c1fd80832c9a86cc1887281ba2