### PR TITLE
Add Goomba enemies with stomp mechanics

### DIFF
--- a/collision.js
+++ b/collision.js
@@ -16,3 +16,13 @@ export function isColliding(a, b) {
     aTop < bBottom
   );
 }
+
+export function playerEnemyCollision(player, enemy) {
+  if (!isColliding(player, enemy)) return null;
+  const playerBottom = player.y + player.height / 2;
+  const enemyTop = enemy.y - enemy.height / 2;
+  if (player.vy > 0 && playerBottom - player.vy <= enemyTop) {
+    return 'top';
+  }
+  return 'side';
+}

--- a/collision.test.js
+++ b/collision.test.js
@@ -1,6 +1,7 @@
 import test from 'node:test';
 import assert from 'node:assert';
 import { isColliding } from './collision.js';
+import { playerEnemyCollision } from './collision.js';
 
 const groundY = 1.5;
 
@@ -51,4 +52,18 @@ test('extended width collider detects earlier collision', () => {
   const obstacle = createEntity(1.45, groundY, 0.32, 0.64);
   assert.strictEqual(isColliding(unicorn, obstacle), false);
   assert.strictEqual(isColliding(shielded, obstacle), true);
+});
+
+test('player stomps enemy when colliding from above', () => {
+  const player = createEntity(0.5, groundY - 0.1, 0.8, 0.8);
+  player.vy = 1;
+  const enemy = createEntity(0.5, groundY, 0.6, 0.6);
+  assert.strictEqual(playerEnemyCollision(player, enemy), 'top');
+});
+
+test('player takes damage when colliding from side', () => {
+  const player = createEntity(0.5, groundY, 0.8, 0.8);
+  player.vy = 0;
+  const enemy = createEntity(0.9, groundY, 0.6, 0.6);
+  assert.strictEqual(playerEnemyCollision(player, enemy), 'side');
 });

--- a/src/entities/goomba.js
+++ b/src/entities/goomba.js
@@ -1,0 +1,20 @@
+export class Goomba {
+  constructor(x, y, speed = 0.5) {
+    this.width = 0.6;
+    this.height = 0.6;
+    this.baseWidth = this.width;
+    this.baseHeight = this.height;
+    this.x = x;
+    this.y = y;
+    this.speed = speed;
+    this.spriteScale = 1;
+  }
+
+  setScale(scale) {
+    this.spriteScale = scale;
+  }
+
+  update(worldMove, delta) {
+    this.x -= worldMove + this.speed * delta;
+  }
+}

--- a/src/levels/level3.js
+++ b/src/levels/level3.js
@@ -4,21 +4,25 @@ import { Goomba } from '../entities/goomba.js';
 import { playerEnemyCollision } from '../../collision.js';
 import { JUMP_VELOCITY } from '../config.js';
 const TILE_MAP = '.....O.G.O...O.G.O....OG..';
-const LAYOUT = [];
-const ENEMY_LAYOUT = [];
-for (let i = 0; i < TILE_MAP.length; i++) {
-  const ch = TILE_MAP[i];
-  if (ch === 'O') LAYOUT.push(i);
-  if (ch === 'G') ENEMY_LAYOUT.push(i);
+function parseTileMap(map) {
+  const layout = [];
+  const enemies = [];
+  for (let i = 0; i < map.length; i++) {
+    const ch = map[i];
+    if (ch === 'O') layout.push(i);
+    if (ch === 'G') enemies.push(i);
+  }
+  return { layout, enemies, length: map.length };
 }
-const LEVEL_LENGTH = TILE_MAP.length;
+const { layout: LAYOUT, enemies: ENEMY_LAYOUT, length: LEVEL_LENGTH } =
+  parseTileMap(TILE_MAP);
 
 // Level 3 - Unicornolandia as a scripted platform section
 export class Level3 extends BaseLevel {
   constructor(game, random = Math.random) {
     super(game, random);
-    this.layout = LAYOUT;
-    this.enemyLayout = ENEMY_LAYOUT;
+    this.layout = [...LAYOUT];
+    this.enemyLayout = [...ENEMY_LAYOUT];
     this.distance = 0; // total distance travelled in world units
     this.nextIndex = 0; // next obstacle to spawn from layout
     this.nextEnemyIndex = 0; // next enemy to spawn from layout

--- a/src/renderer.js
+++ b/src/renderer.js
@@ -256,6 +256,22 @@ export class Renderer {
     });
   }
 
+  drawEnemies() {
+    const { game } = this;
+    this.withContext(ctx => {
+      const scale = this.game.scale;
+      game.level.enemies.forEach(e => {
+        const w = e.width * scale * SPRITE_SCALE;
+        const h = e.height * scale * SPRITE_SCALE;
+        const left = e.x * scale - w / 2;
+        const bottom = (e.y + e.height / 2) * scale;
+        const top = bottom - h;
+        ctx.fillStyle = 'brown';
+        ctx.fillRect(left, top, w, h);
+      });
+    });
+  }
+
   drawWalls() {
     const { game } = this;
     this.withContext(ctx => {
@@ -387,6 +403,9 @@ export class Renderer {
     this.drawPlayer();
     if (game.level.obstacles) {
       this.drawObstacles();
+    }
+    if (game.level.enemies) {
+      this.drawEnemies();
     }
     if (game.level.walls) {
       this.drawWalls();


### PR DESCRIPTION
## Summary
- Add `Goomba` entity and collision helpers for player vs enemy interactions
- Spawn enemies in level 3 using a tile map and handle stomp or side collisions
- Render enemies and add tests covering enemy collision types

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68af81c74408832ca8c776ba83284be6