### PR TITLE
feat: auto advance to level 3

### DIFF
--- a/level2.test.js
+++ b/level2.test.js
@@ -2,6 +2,7 @@ import test from 'node:test';
 import assert from 'node:assert';
 import { createStubGame } from './testHelpers.js';
 import { Level2 } from './src/levels/level2.js';
+import { Level3 } from './src/levels/level3.js';
 import { SHIELD_COOLDOWN } from './src/config.js';
 
 const FRAME = 1 / 60;
@@ -161,4 +162,16 @@ test('missing grace window results in game over', () => {
     level.update(FRAME);
   }
   assert.strictEqual(game.gameOver, true);
+});
+
+test('game advances to level 3 after defeating level 2 boss', () => {
+  const game = createStubGame({ search: '?level=2' });
+  const level = game.level;
+  level.bossFlee = true;
+  level.boss.x = game.worldWidth + 1;
+  game.update(FRAME);
+  assert.strictEqual(game.levelNumber, 3);
+  assert.ok(game.level instanceof Level3);
+  assert.strictEqual(game.gameOver, false);
+  assert.strictEqual(game.win, false);
 });

--- a/src/game.js
+++ b/src/game.js
@@ -241,6 +241,17 @@ export class Game {
       });
     }
 
+    if (this.levelNumber === 2 && this.gameOver && this.win) {
+      this.levelNumber = 3;
+      this.initializeLevel();
+      this.gamePaused = true;
+      this.gameOver = false;
+      this.win = false;
+      this.showOverlay(STORY_TEXT[2], () => {
+        this.showOverlay(INSTRUCTIONS_TEXT[3], () => this.startLoop());
+      });
+    }
+
     if (this.gameOver) this.gamePaused = true;
   }
 
@@ -276,7 +287,9 @@ export class Game {
     if (this.gameOver) {
       if (this.win) {
         this.input.detach();
-        this.showOverlay(STORY_TEXT[2], () => { this.gamePaused = false; });
+        this.showOverlay(STORY_TEXT[this.levelNumber], () => {
+          this.gamePaused = false;
+        });
       } else {
         requestAnimationFrame(ts => this.loop(ts));
       }


### PR DESCRIPTION
## Summary
- transition to level 3 automatically after beating level 2's boss
- show story text based on current level when winning
- test level 2 victory advances to level 3

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68af824e8c24832c917e8861f3e3f771