### PR TITLE
Add Goomba enemies with stomping collisions

### DIFF
--- a/collision.js
+++ b/collision.js
@@ -16,3 +16,16 @@ export function isColliding(a, b) {
     aTop < bBottom
   );
 }
+
+export function isLandingOn(a, b) {
+  if (!isColliding(a, b)) return false;
+  const aBottom = a.y + a.height / 2;
+  const bTop = b.y - b.height / 2;
+  const verticalOverlap = aBottom - bTop;
+  const aRight = a.x + a.width / 2;
+  const aLeft = a.x - a.width / 2;
+  const bRight = b.x + b.width / 2;
+  const bLeft = b.x - b.width / 2;
+  const horizontalOverlap = Math.min(aRight, bRight) - Math.max(aLeft, bLeft);
+  return verticalOverlap < horizontalOverlap && a.vy > 0;
+}

--- a/level3.test.js
+++ b/level3.test.js
@@ -2,6 +2,7 @@ import test from 'node:test';
 import assert from 'node:assert';
 import { createStubGame } from './testHelpers.js';
 import { LEVEL3_MAP } from './src/levels/level3.js';
+import { Goomba } from './src/entities/goomba.js';
 
 const FRAME = 1 / 60;
 
@@ -12,6 +13,7 @@ test('level 3 builds entities from tile map', () => {
   assert.deepStrictEqual(level.map, LEVEL3_MAP);
   assert.ok(level.platforms.length > 0);
   assert.ok(level.pipes.length > 0);
+  assert.ok(level.enemies.length > 0);
 });
 
 // Distance travelled should increase according to the move speed.
@@ -41,5 +43,34 @@ test('level 3 maps space to jump', () => {
   game.handleInput();
   assert.strictEqual(player.jumping, true);
   assert.strictEqual(player.shieldActive, false);
+});
+
+test('player defeats enemy by landing on it', () => {
+  const game = createStubGame({ search: '?level=3' });
+  const level = game.level;
+  const player = game.player;
+  const enemy = new Goomba(player.x + 0.2, game.groundY - 0.5, 1);
+  level.enemies = [enemy];
+  level.obstacles = [...level.platforms, ...level.pipes, ...level.blocks, enemy];
+  player.x = enemy.x;
+  player.y = enemy.y - enemy.height / 2 - player.height / 2 + 0.01;
+  player.vy = 1; // falling
+  level.update(FRAME);
+  assert.strictEqual(level.enemies.length, 0);
+  assert.strictEqual(game.gameOver, false);
+});
+
+test('player is hit when colliding with enemy from side', () => {
+  const game = createStubGame({ search: '?level=3' });
+  const level = game.level;
+  const player = game.player;
+  const enemy = new Goomba(player.x + 0.5, game.groundY - 0.5, 1);
+  level.enemies = [enemy];
+  level.obstacles = [...level.platforms, ...level.pipes, ...level.blocks, enemy];
+  player.x = enemy.x - enemy.width / 2 - player.width / 2 + 0.01;
+  player.y = enemy.y;
+  player.vy = 0;
+  level.update(FRAME);
+  assert.strictEqual(game.gameOver, true);
 });
 

--- a/src/entities/goomba.js
+++ b/src/entities/goomba.js
@@ -1,0 +1,26 @@
+export class Goomba {
+  constructor(x, y, size = 1) {
+    this.x = x;
+    this.y = y;
+    this.width = size;
+    this.height = size;
+    this.baseWidth = size;
+    this.baseHeight = size;
+    this.spriteScale = 1;
+    // Horizontal speed relative to the world
+    this.vx = -0.5;
+  }
+
+  setScale(scale) {
+    this.spriteScale = scale;
+  }
+
+  update(scroll, delta) {
+    // Move with the level scroll
+    this.x -= scroll;
+    // Apply own walking velocity
+    if (delta !== undefined) {
+      this.x += this.vx * delta;
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- add simple Goomba enemy entity with horizontal movement
- populate Level 3 with Goombas from tile map and update collisions to allow stomping
- extend collision helper to detect vertical landings on enemies

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68af84233f24832caf7b5dab11f90f1f