### PR TITLE
Enable double jump in Level 3

### DIFF
--- a/level3.test.js
+++ b/level3.test.js
@@ -3,6 +3,7 @@ import assert from 'node:assert';
 import { createStubGame } from './testHelpers.js';
 import { LEVEL3_MAP } from './src/levels/level3.js';
 import { Goomba } from './src/entities/goomba.js';
+import { JUMP_VELOCITY } from './src/config.js';
 
 const FRAME = 1 / 60;
 
@@ -72,5 +73,26 @@ test('player is hit when colliding with enemy from side', () => {
   player.vy = 0;
   level.update(FRAME);
   assert.strictEqual(game.gameOver, true);
+});
+
+test('player can double jump in level 3', () => {
+  const game = createStubGame({ search: '?level=3', skipLevelUpdate: true });
+  const player = game.player;
+  player.jump();
+  game.update(FRAME);
+  player.jump();
+  assert.strictEqual(player.jumpCount, 2);
+  assert.strictEqual(player.vy, JUMP_VELOCITY);
+});
+
+test('player cannot triple jump in level 3', () => {
+  const game = createStubGame({ search: '?level=3', skipLevelUpdate: true });
+  const player = game.player;
+  player.jump();
+  game.update(FRAME);
+  player.jump();
+  game.update(FRAME);
+  player.jump();
+  assert.strictEqual(player.jumpCount, 2);
 });
 

--- a/src/levels/level3.js
+++ b/src/levels/level3.js
@@ -53,6 +53,7 @@ class Block extends Obstacle {
 export class Level3 extends BaseLevel {
   constructor(game, random = Math.random) {
     super(game, random);
+    this.game.player.maxJumps = 2;
     this.map = MAP;
     this.tileSize = 1; // world units per tile
     this.distance = 0;
@@ -141,6 +142,7 @@ export class Level3 extends BaseLevel {
       if (isLandingOn(player, e)) {
         player.vy = JUMP_VELOCITY / 2;
         player.jumping = true;
+        player.jumpCount = 1;
         return false;
       }
       if (isColliding(player, e)) {

--- a/src/player.js
+++ b/src/player.js
@@ -20,6 +20,8 @@ export class Player {
     this.moveSpeed = 3;
     this.worldWidth = 0; // to be set by game
     this.jumping = false;
+    this.jumpCount = 0;
+    this.maxJumps = 1;
     this.shieldActive = false;
     this.shieldTimer = 0;
     this.shieldCooldown = 0;
@@ -38,6 +40,7 @@ export class Player {
       this.y = groundY - this.height / 2;
       this.vy = 0;
       this.jumping = false;
+      this.jumpCount = 0;
     }
     this.x += this.vx * delta;
     if (this.worldWidth) {
@@ -56,9 +59,10 @@ export class Player {
   }
 
   jump() {
-    if (!this.jumping) {
+    if (this.jumpCount < this.maxJumps) {
       this.vy = JUMP_VELOCITY;
       this.jumping = true;
+      this.jumpCount++;
     }
   }
 


### PR DESCRIPTION
## Summary
- Allow the player to perform up to two consecutive jumps via jumpCount/maxJumps tracking
- Grant double-jump ability when playing Level 3 and reset jump after stomping enemies
- Add tests covering double jump behaviour in Level 3

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68af8899a67c832c9a90af911d3ff103