### PR TITLE
feat: introduce unique enemies for level 3

### DIFF
--- a/level1.test.js
+++ b/level1.test.js
@@ -1,6 +1,9 @@
 import test from 'node:test';
 import assert from 'node:assert';
 import { createStubGame } from './testHelpers.js';
+import { ShadowCrow } from './src/entities/shadowCrow.js';
+import { FollettiRombo } from './src/entities/follettiRombo.js';
+import { ThornGuard } from './src/entities/thornGuard.js';
 
 test('level 1 obstacles have tree dimensions', () => {
   const game = createStubGame({ search: '?level=1' });
@@ -35,4 +38,18 @@ test('level 1 ignores horizontal movement', () => {
   game.handleInput('ArrowRight', 'down');
   player.update(0, game.groundY, 1);
   assert.strictEqual(player.x, startX);
+});
+
+test('level 1 has no level 3 enemies', () => {
+  const game = createStubGame({ search: '?level=1', skipLevelUpdate: true });
+  const level = game.level;
+  const obstacles = level.obstacles || [];
+  const enemies = level.enemies || [];
+  const has = [...obstacles, ...enemies].some(
+    e =>
+      e instanceof ShadowCrow ||
+      e instanceof FollettiRombo ||
+      e instanceof ThornGuard
+  );
+  assert.strictEqual(has, false);
 });

--- a/level2.test.js
+++ b/level2.test.js
@@ -4,6 +4,9 @@ import { createStubGame } from './testHelpers.js';
 import { Level2 } from './src/levels/level2.js';
 import { Level3 } from './src/levels/level3.js';
 import { SHIELD_COOLDOWN } from './src/config.js';
+import { ShadowCrow } from './src/entities/shadowCrow.js';
+import { FollettiRombo } from './src/entities/follettiRombo.js';
+import { ThornGuard } from './src/entities/thornGuard.js';
 
 const FRAME = 1 / 60;
 
@@ -123,13 +126,27 @@ test('shield blocks obstacles slightly earlier', () => {
   assert.ok(!level.handleCollision(wall));
 });
 
-test('shield cooldown bar uses latest cooldown value', () => {
-  const game = createStubGame({ search: '?level=2', skipLevelUpdate: true });
-  const player = game.player;
-  assert.strictEqual(player.shieldCooldownMax, SHIELD_COOLDOWN);
-  player.activateShield(0.25, 2);
-  assert.strictEqual(player.shieldCooldownMax, 2);
-});
+  test('shield cooldown bar uses latest cooldown value', () => {
+    const game = createStubGame({ search: '?level=2', skipLevelUpdate: true });
+    const player = game.player;
+    assert.strictEqual(player.shieldCooldownMax, SHIELD_COOLDOWN);
+    player.activateShield(0.25, 2);
+    assert.strictEqual(player.shieldCooldownMax, 2);
+  });
+
+  test('level 2 has no level 3 enemies', () => {
+    const game = createStubGame({ search: '?level=2', skipLevelUpdate: true });
+    const level = game.level;
+    const obstacles = level.obstacles || [];
+    const enemies = level.enemies || [];
+    const has = [...obstacles, ...enemies].some(
+      e =>
+        e instanceof ShadowCrow ||
+        e instanceof FollettiRombo ||
+        e instanceof ThornGuard
+    );
+    assert.strictEqual(has, false);
+  });
 
 test('shield activation within grace window blocks attack', () => {
   const game = createStubGame({ search: '?level=2' });

--- a/src/entities/follettiRombo.js
+++ b/src/entities/follettiRombo.js
@@ -1,0 +1,41 @@
+export class FollettiRombo {
+  constructor(x, y, size = 1) {
+    this.x = x;
+    this.y = y;
+    this.width = size;
+    this.height = size;
+    this.baseWidth = size;
+    this.baseHeight = size;
+    this.spriteScale = 1;
+    this.vx = -0.4;
+    this.dashSpeed = -2;
+    this.dashTime = 0.2;
+    this.cooldown = 1.5;
+    this.timer = 0;
+    this.dashing = false;
+    this.dashTimer = 0;
+  }
+
+  setScale(scale) {
+    this.spriteScale = scale;
+  }
+
+  update(scroll, delta = 0) {
+    this.x -= scroll;
+    if (this.dashing) {
+      this.x += this.dashSpeed * delta;
+      this.dashTimer -= delta;
+      if (this.dashTimer <= 0) {
+        this.dashing = false;
+        this.timer = 0;
+      }
+    } else {
+      this.x += this.vx * delta;
+      this.timer += delta;
+      if (this.timer >= this.cooldown) {
+        this.dashing = true;
+        this.dashTimer = this.dashTime;
+      }
+    }
+  }
+}

--- a/src/entities/shadowCrow.js
+++ b/src/entities/shadowCrow.js
@@ -1,0 +1,31 @@
+export class ShadowCrow {
+  constructor(x, y, size = 1) {
+    this.x = x;
+    this.y = y;
+    this.width = size;
+    this.height = size;
+    this.baseWidth = size;
+    this.baseHeight = size;
+    this.spriteScale = 1;
+    // horizontal speed
+    this.vx = -0.6;
+    // sine wave parameters
+    this.baseY = y;
+    this.time = 0;
+    this.amplitude = size / 2;
+    this.frequency = 3;
+  }
+
+  setScale(scale) {
+    this.spriteScale = scale;
+  }
+
+  update(scroll, delta = 0) {
+    // move with level scroll
+    this.x -= scroll;
+    // apply own velocity and sine movement
+    this.x += this.vx * delta;
+    this.time += delta;
+    this.y = this.baseY + Math.sin(this.time * this.frequency) * this.amplitude;
+  }
+}

--- a/src/entities/thornGuard.js
+++ b/src/entities/thornGuard.js
@@ -1,0 +1,40 @@
+import { Obstacle } from '../obstacle.js';
+
+export class ThornGuard {
+  constructor(x, y, size = 1) {
+    this.x = x;
+    this.y = y;
+    this.width = size;
+    this.height = size;
+    this.baseWidth = size;
+    this.baseHeight = size;
+    this.spriteScale = 1;
+    this.vx = -0.3;
+    this.throwCooldown = 2; // seconds
+    this.timer = 0;
+    this.seedSize = size * 0.5;
+  }
+
+  setScale(scale) {
+    this.spriteScale = scale;
+  }
+
+  update(scroll, delta = 0) {
+    this.x -= scroll;
+    this.x += this.vx * delta;
+    this.timer += delta;
+    const seeds = [];
+    if (this.timer >= this.throwCooldown) {
+      this.timer = 0;
+      const seed = new Obstacle(
+        this.x - this.width / 2 - this.seedSize / 2,
+        this.y,
+        this.seedSize,
+        this.seedSize
+      );
+      seed.setScale(this.spriteScale);
+      seeds.push(seed);
+    }
+    return seeds;
+  }
+}

--- a/src/levels/level3.js
+++ b/src/levels/level3.js
@@ -1,18 +1,23 @@
 import { BaseLevel } from './baseLevel.js';
 import { Obstacle } from '../obstacle.js';
-import { Goomba } from '../entities/goomba.js';
+import { ShadowCrow } from '../entities/shadowCrow.js';
+import { FollettiRombo } from '../entities/follettiRombo.js';
+import { ThornGuard } from '../entities/thornGuard.js';
 import { isColliding, isLandingOn } from '../../collision.js';
 import { JUMP_VELOCITY } from '../config.js';
 
 // Tile identifiers inspired by tylerreichle/mario_js.
-// 0 = empty, 1 = ground, 2 = platform, 3 = pipe, 4 = block, 5 = enemy
+// 0 = empty, 1 = ground, 2 = platform, 3 = pipe, 4 = block
+// 5 = shadow crow, 6 = folletti-rombo, 7 = thorn guard
 const TILE = {
   EMPTY: 0,
   GROUND: 1,
   PLATFORM: 2,
   PIPE: 3,
   BLOCK: 4,
-  GOOMBA: 5,
+  SHADOW_CROW: 5,
+  FOLLETTI_ROMBO: 6,
+  THORN_GUARD: 7,
 };
 
 // Two dimensional map describing the level layout. Each number
@@ -22,7 +27,7 @@ const MAP = [
   // Ground row
   [1, 1, 1, 1, 1, 1, 1, 1],
   // Tiles one unit above the ground
-  [5, 2, 0, 3, 5, 2, 0, 0],
+  [7, 2, 0, 3, 5, 2, 0, 6],
   // Tiles two units above the ground
   [0, 0, 0, 0, 4, 0, 0, 0],
 ];
@@ -93,10 +98,31 @@ export class Level3 extends BaseLevel {
           case TILE.BLOCK:
             this.blocks.push(new Block(x, y, this.tileSize));
             break;
-          case TILE.GOOMBA:
-            // Enemies always spawn on the ground regardless of row
+          case TILE.SHADOW_CROW:
             this.enemies.push(
-              new Goomba(x, this.game.groundY - this.tileSize / 2, this.tileSize)
+              new ShadowCrow(
+                x,
+                this.game.groundY - this.tileSize * 2,
+                this.tileSize
+              )
+            );
+            break;
+          case TILE.FOLLETTI_ROMBO:
+            this.enemies.push(
+              new FollettiRombo(
+                x,
+                this.game.groundY - this.tileSize / 2,
+                this.tileSize
+              )
+            );
+            break;
+          case TILE.THORN_GUARD:
+            this.enemies.push(
+              new ThornGuard(
+                x,
+                this.game.groundY - this.tileSize / 2,
+                this.tileSize
+              )
             );
             break;
           default:
@@ -120,7 +146,12 @@ export class Level3 extends BaseLevel {
     moveArr(this.platforms);
     moveArr(this.pipes);
     moveArr(this.blocks);
-    this.enemies.forEach(e => e.update(move, delta));
+    this.enemies.forEach(e => {
+      const spawned = e.update(move, delta);
+      if (spawned && spawned.length) {
+        this.blocks.push(...spawned);
+      }
+    });
 
     const player = this.game.player;
     const collideArr = arr => {


### PR DESCRIPTION
## Summary
- add Shadow Crow, Folletti-Rombo and Thorn Guard enemy classes
- populate level 3 with new enemies and seed walls
- verify new foes stay exclusive to level 3

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68af8a72bdfc832cb871cb34f38b053f