### PR TITLE
Add star dust collectibles and final portal to level 3

### DIFF
--- a/level1.test.js
+++ b/level1.test.js
@@ -36,3 +36,11 @@ test('level 1 ignores horizontal movement', () => {
   player.update(0, game.groundY, 1);
   assert.strictEqual(player.x, startX);
 });
+
+test('level 1 has no star powders or key', () => {
+  const game = createStubGame({ search: '?level=1', skipLevelUpdate: true });
+  const level = game.level;
+  assert.ok(!('starPowders' in level));
+  assert.ok(!('crystalKey' in level));
+  assert.ok(!('portal' in level));
+});

--- a/level2.test.js
+++ b/level2.test.js
@@ -24,6 +24,14 @@ test('level 2 ignores horizontal movement', () => {
   assert.strictEqual(player.x, startX);
 });
 
+test('level 2 has no star powders or key', () => {
+  const game = createStubGame({ search: '?level=2', skipLevelUpdate: true });
+  const level = game.level;
+  assert.ok(!('starPowders' in level));
+  assert.ok(!('crystalKey' in level));
+  assert.ok(!('portal' in level));
+});
+
 test('player covers 80% of distance after destroying 15 walls', () => {
   const game = createStubGame({ skipLevelUpdate: true });
   const level = new Level2(game);

--- a/level3.test.js
+++ b/level3.test.js
@@ -25,16 +25,43 @@ test('level 3 advances using move speed', () => {
   assert.strictEqual(level.distance, level.getMoveSpeed());
 });
 
-// After travelling the entire level and clearing entities the level should end.
-test('level 3 completes after level length', () => {
+test('level 3 starts with star powders and a crystal key', () => {
+  const game = createStubGame({ search: '?level=3', skipLevelUpdate: true });
+  const level = game.level;
+  assert.strictEqual(level.starPowders.length, 30);
+  assert.ok(level.crystalKey);
+  assert.strictEqual(level.portal, null);
+});
+
+test('portal activates after collecting star powders and key', () => {
   const game = createStubGame({ search: '?level=3' });
   const level = game.level;
-  let steps = 0;
-  while (!game.win && steps < 5000) {
-    level.update(FRAME);
-    steps++;
-  }
-  assert.ok(game.win);
+  const player = game.player;
+
+  // collect all star powders
+  level.starPowders.forEach(s => {
+    s.x = player.x;
+    s.y = player.y;
+  });
+  level.update(0);
+  assert.strictEqual(level.starPowders.length, 0);
+
+  // collect the key
+  level.crystalKey.x = player.x;
+  level.crystalKey.y = player.y;
+  level.update(0);
+  assert.strictEqual(level.crystalKey, null);
+
+  // portal should appear
+  level.update(0);
+  assert.ok(level.portal);
+
+  // touch the portal to win
+  level.portal.x = player.x;
+  level.portal.y = player.y;
+  level.update(0);
+  assert.strictEqual(game.gameOver, true);
+  assert.strictEqual(game.win, true);
 });
 
 // Level 3 uses jump instead of shield when pressing the action button


### PR DESCRIPTION
## Summary
- Spawn 30 Star Powder collectibles and a Crystal Key exclusively in level 3
- Activate a Rainbow Portal in level 3 once all collectibles are gathered
- Add regression tests ensuring other levels lack these items and portal logic works

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68af8afc5d44832ca904a3fe089da776