### PR TITLE
Add exclusive enemies to level 3

### DIFF
--- a/src/entities/rhombusSprite.js
+++ b/src/entities/rhombusSprite.js
@@ -1,0 +1,39 @@
+export class RhombusSprite {
+  constructor(x, y, size = 1) {
+    this.x = x;
+    this.y = y;
+    this.width = size;
+    this.height = size;
+    this.baseWidth = size;
+    this.baseHeight = size;
+    this.spriteScale = 1;
+    this.state = 'waiting';
+    this.timer = 0;
+    this.dashInterval = 0.5; // seconds between dashes
+    this.dashDuration = 0.2; // seconds dash lasts
+    this.dashSpeed = -2; // relative speed during dash
+  }
+
+  setScale(scale) {
+    this.spriteScale = scale;
+  }
+
+  update(scroll, delta) {
+    this.x -= scroll;
+    if (delta !== undefined) {
+      this.timer += delta;
+      if (this.state === 'waiting') {
+        if (this.timer >= this.dashInterval) {
+          this.state = 'dashing';
+          this.timer = 0;
+        }
+      } else if (this.state === 'dashing') {
+        this.x += this.dashSpeed * delta;
+        if (this.timer >= this.dashDuration) {
+          this.state = 'waiting';
+          this.timer = 0;
+        }
+      }
+    }
+  }
+}

--- a/src/entities/shadowCrow.js
+++ b/src/entities/shadowCrow.js
@@ -1,0 +1,30 @@
+export class ShadowCrow {
+  constructor(x, y, size = 1, amplitude = 0.5, frequency = 1) {
+    this.x = x;
+    this.y = y;
+    this.baseY = y;
+    this.width = size;
+    this.height = size;
+    this.baseWidth = size;
+    this.baseHeight = size;
+    this.spriteScale = 1;
+    this.amplitude = amplitude;
+    this.frequency = frequency; // cycles per second
+    this.time = 0;
+  }
+
+  setScale(scale) {
+    this.spriteScale = scale;
+  }
+
+  update(scroll, delta) {
+    // Move with level scroll
+    this.x -= scroll;
+    if (delta !== undefined) {
+      this.time += delta;
+      // Vertical sinusoidal movement
+      const angle = this.time * this.frequency * Math.PI * 2;
+      this.y = this.baseY + Math.sin(angle) * this.amplitude;
+    }
+  }
+}

--- a/src/entities/thornGuard.js
+++ b/src/entities/thornGuard.js
@@ -1,0 +1,41 @@
+import { Obstacle } from '../obstacle.js';
+
+export class ThornGuard {
+  constructor(x, y, size = 1) {
+    this.x = x;
+    this.y = y;
+    this.width = size;
+    this.height = size;
+    this.baseWidth = size;
+    this.baseHeight = size;
+    this.spriteScale = 1;
+    this.throwInterval = 1; // seconds between throws
+    this.timer = 0;
+  }
+
+  setScale(scale) {
+    this.spriteScale = scale;
+  }
+
+  update(scroll, delta) {
+    this.x -= scroll;
+    const spawned = [];
+    if (delta !== undefined) {
+      this.timer += delta;
+      if (this.timer >= this.throwInterval) {
+        this.timer = 0;
+        const width = this.width * 0.3;
+        const height = this.height * 0.5; // semi-wall
+        const wall = new Obstacle(
+          this.x - this.width / 2 - width / 2,
+          this.y,
+          width,
+          height
+        );
+        wall.setScale(this.spriteScale);
+        spawned.push(wall);
+      }
+    }
+    return spawned;
+  }
+}


### PR DESCRIPTION
## Summary
- Introduce Shadow Crow, Rhombus Sprite, and Thorn Guard enemy classes
- Spawn new enemies only in level 3 and manage their behaviors including seed-wall projectiles
- Expand tests to verify exclusive enemies and their movement patterns

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68af8c16406c832c977d8453b0c14c02