### PR TITLE
Add unique Level 3 obstacles

### DIFF
--- a/level1.test.js
+++ b/level1.test.js
@@ -36,3 +36,11 @@ test('level 1 ignores horizontal movement', () => {
   player.update(0, game.groundY, 1);
   assert.strictEqual(player.x, startX);
 });
+
+test('level 1 lacks level 3 exclusive obstacles', () => {
+  const game = createStubGame({ search: '?level=1', skipLevelUpdate: true });
+  const level = game.level;
+  assert.ok(!level.thorns);
+  assert.ok(!level.moonMilks);
+  assert.ok(!level.seedWalls);
+});

--- a/level2.test.js
+++ b/level2.test.js
@@ -175,3 +175,11 @@ test('game advances to level 3 after defeating level 2 boss', () => {
   assert.strictEqual(game.gameOver, false);
   assert.strictEqual(game.win, false);
 });
+
+test('level 2 lacks level 3 exclusive obstacles', () => {
+  const game = createStubGame({ search: '?level=2', skipLevelUpdate: true });
+  const level = game.level;
+  assert.ok(!level.thorns);
+  assert.ok(!level.moonMilks);
+  assert.ok(!level.seedWalls);
+});

--- a/src/renderer.js
+++ b/src/renderer.js
@@ -331,8 +331,8 @@ export class Renderer {
             ctx.arc(left + r * 2, top + r * 0.5, r, 0, Math.PI * 2);
             ctx.arc(left + r * 3, top + r, r, 0, Math.PI * 2);
             ctx.fill();
-          } else if (o.type === 'pipe') {
-            // Purple brambles
+          } else if (o.type === 'thorn') {
+            // Purple thorns
             ctx.fillStyle = '#a64ac9';
             ctx.fillRect(left, top, w, h);
             ctx.fillStyle = '#8e24aa';
@@ -343,12 +343,16 @@ export class Renderer {
               ctx.lineTo(left + i + w / 5, top);
               ctx.fill();
             }
-          } else if (o.type === 'block') {
+          } else if (o.type === 'moonmilk') {
             // Moon milk lakes
             ctx.fillStyle = '#f0f8ff';
             ctx.fillRect(left, top, w, h);
             ctx.strokeStyle = '#d0eaff';
             ctx.strokeRect(left, top, w, h);
+          } else if (o.type === 'seedWall') {
+            // Seed walls
+            ctx.fillStyle = '#8b4513';
+            ctx.fillRect(left, top, w, h);
           } else {
             // Enemies or other objects
             ctx.fillStyle = '#ffb7ce';


### PR DESCRIPTION
## Summary
- Introduce Level 3 exclusive obstacles: purple thorns, moon milk pools, and seed walls
- Implement respawn-at-checkpoint mechanic for moon milk and shield-breakable seed walls
- Update renderer and tests to cover new obstacles and ensure Levels 1 & 2 remain unaffected

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68af8c3ac6e8832ca3b7b59a081fbe75