### PR TITLE
Add Level 3 power-ups with HUD icons

### DIFF
--- a/powerups.test.js
+++ b/powerups.test.js
@@ -1,0 +1,63 @@
+import test from 'node:test';
+import assert from 'node:assert';
+import { createStubGame } from './testHelpers.js';
+import {
+  AURA_SHIELD_DURATION,
+  ZOCCOLI_VENTO_DURATION,
+  ALI_DI_ZUCCHERO_DURATION,
+} from './src/config.js';
+
+const FRAME = 1 / 60;
+
+function runFor(game, seconds) {
+  for (let t = 0; t < seconds; t += FRAME) {
+    game.update(FRAME);
+  }
+}
+
+test('special power-ups spawn only in level 3', () => {
+  const g1 = createStubGame({ search: '?level=1' });
+  assert.strictEqual(g1.level.powerUps, undefined);
+  const g2 = createStubGame({ search: '?level=2' });
+  assert.strictEqual(g2.level.powerUps, undefined);
+  const g3 = createStubGame({ search: '?level=3' });
+  assert.ok(Array.isArray(g3.level.powerUps));
+  assert.strictEqual(g3.level.powerUps.length, 3);
+});
+
+function collect(game, kind) {
+  const level = game.level;
+  const player = game.player;
+  const p = level.powerUps.find(pu => pu.kind === kind);
+  player.x = p.x;
+  player.y = p.y;
+  level.update(0); // trigger pickup without movement
+  return player;
+}
+
+test('power-ups grant temporary effects', () => {
+  // Aura-Shield
+  let game = createStubGame({ search: '?level=3' });
+  let player = collect(game, 'aura');
+  assert.ok(player.shieldActive);
+  runFor(game, AURA_SHIELD_DURATION + FRAME);
+  assert.ok(!player.shieldActive);
+
+  // Wind-Hooves
+  game = createStubGame({ search: '?level=3' });
+  player = game.player;
+  const baseSpeed = player.moveSpeed;
+  collect(game, 'wind');
+  assert.ok(player.moveSpeed > baseSpeed);
+  runFor(game, ZOCCOLI_VENTO_DURATION + FRAME);
+  assert.strictEqual(player.moveSpeed, baseSpeed);
+
+  // Sugar-Wings
+  game = createStubGame({ search: '?level=3' });
+  player = game.player;
+  const baseJumps = player.maxJumps;
+  collect(game, 'wings');
+  assert.ok(player.maxJumps > baseJumps);
+  runFor(game, ALI_DI_ZUCCHERO_DURATION + FRAME);
+  assert.strictEqual(player.maxJumps, baseJumps);
+});

--- a/src/config.js
+++ b/src/config.js
@@ -27,3 +27,8 @@ export const SHIELD_COOLDOWN = 0.9;
 export const SHIELD_DURATION = 0.5;
 // Grace window after an attack where the shield can still be activated (seconds)
 export const SHIELD_GRACE = 0.16;
+
+// Durations for Level 3 special power-ups (seconds)
+export const AURA_SHIELD_DURATION = 5;
+export const ZOCCOLI_VENTO_DURATION = 4;
+export const ALI_DI_ZUCCHERO_DURATION = 6;

--- a/src/levels/level3.js
+++ b/src/levels/level3.js
@@ -2,7 +2,12 @@ import { BaseLevel } from './baseLevel.js';
 import { Obstacle } from '../obstacle.js';
 import { Goomba } from '../entities/goomba.js';
 import { isColliding, isLandingOn } from '../../collision.js';
-import { JUMP_VELOCITY } from '../config.js';
+import {
+  JUMP_VELOCITY,
+  AURA_SHIELD_DURATION,
+  ZOCCOLI_VENTO_DURATION,
+  ALI_DI_ZUCCHERO_DURATION,
+} from '../config.js';
 
 // Tile identifiers inspired by tylerreichle/mario_js.
 // 0 = empty, 1 = ground, 2 = platform, 3 = pipe, 4 = block, 5 = enemy
@@ -49,11 +54,19 @@ class Block extends Obstacle {
   }
 }
 
+class PowerUp extends Obstacle {
+  constructor(x, y, size, kind) {
+    super(x, y, size, size);
+    this.kind = kind;
+  }
+}
+
 // Level 3 - Unicornolandia converted to a tile-based platform section
 export class Level3 extends BaseLevel {
   constructor(game, random = Math.random) {
     super(game, random);
     this.game.player.maxJumps = 2;
+    this.game.player.baseMaxJumps = 2;
     this.map = MAP;
     this.tileSize = 1; // world units per tile
     this.distance = 0;
@@ -62,7 +75,9 @@ export class Level3 extends BaseLevel {
     this.pipes = [];
     this.blocks = [];
     this.enemies = [];
+    this.powerUps = [];
     this.generateFromMap();
+    this.createPowerUps();
   }
 
   // Spawn interval from BaseLevel isn't used anymore but kept for
@@ -156,6 +171,7 @@ export class Level3 extends BaseLevel {
     this.platforms = filterArr(this.platforms);
     this.pipes = filterArr(this.pipes);
     this.blocks = filterArr(this.blocks);
+    moveArr(this.powerUps);
     this.obstacles = [
       ...this.platforms,
       ...this.pipes,
@@ -163,16 +179,60 @@ export class Level3 extends BaseLevel {
       ...this.enemies,
     ];
 
-    if (this.distance >= this.levelLength && this.obstacles.length === 0) {
+    this.powerUps = this.powerUps.filter(p => {
+      if (isColliding(player, p)) {
+        switch (p.kind) {
+          case 'aura':
+            player.activateShield(AURA_SHIELD_DURATION, 0);
+            player.powerUps.aura = AURA_SHIELD_DURATION;
+            break;
+          case 'wind':
+            player.moveSpeed = player.baseMoveSpeed * 1.5;
+            player.powerUps.wind = ZOCCOLI_VENTO_DURATION;
+            break;
+          case 'wings':
+            player.maxJumps = player.baseMaxJumps + 1;
+            player.powerUps.wings = ALI_DI_ZUCCHERO_DURATION;
+            break;
+          default:
+            break;
+        }
+        return false;
+      }
+      return p.x + p.width / 2 > 0;
+    });
+
+    if (
+      this.distance >= this.levelLength &&
+      this.obstacles.length === 0 &&
+      this.powerUps.length === 0
+    ) {
       this.game.gameOver = true;
       this.game.win = true;
     }
   }
 
   setScale(scale) {
-    [...this.platforms, ...this.pipes, ...this.blocks, ...this.enemies].forEach(
-      o => o.setScale(scale)
-    );
+    [
+      ...this.platforms,
+      ...this.pipes,
+      ...this.blocks,
+      ...this.enemies,
+      ...this.powerUps,
+    ].forEach(o => o.setScale(scale));
+  }
+
+  createPowerUps() {
+    const placements = [
+      { col: 1, row: 2, kind: 'aura' },
+      { col: 3, row: 2, kind: 'wind' },
+      { col: 6, row: 2, kind: 'wings' },
+    ];
+    placements.forEach(p => {
+      const x = this.game.worldWidth + p.col * this.tileSize + this.tileSize / 2;
+      const y = this.game.groundY - p.row * this.tileSize - this.tileSize / 2;
+      this.powerUps.push(new PowerUp(x, y, this.tileSize, p.kind));
+    });
   }
 }
 

--- a/src/player.js
+++ b/src/player.js
@@ -18,15 +18,19 @@ export class Player {
     this.vy = 0;
     this.vx = 0;
     this.moveSpeed = 3;
+    this.baseMoveSpeed = this.moveSpeed;
     this.worldWidth = 0; // to be set by game
     this.jumping = false;
     this.jumpCount = 0;
     this.maxJumps = 1;
+    this.baseMaxJumps = this.maxJumps;
     this.shieldActive = false;
     this.shieldTimer = 0;
     this.shieldCooldown = 0;
     this.shieldCooldownMax = SHIELD_COOLDOWN;
     this.dead = false;
+    // Track active power-ups with remaining duration
+    this.powerUps = {};
   }
 
   setScale(scale) {
@@ -55,6 +59,19 @@ export class Player {
     if (this.shieldCooldown > 0) {
       this.shieldCooldown -= delta;
       if (this.shieldCooldown < 0) this.shieldCooldown = 0;
+    }
+
+    // Update active power-up timers and revert effects when they expire
+    for (const [key, time] of Object.entries(this.powerUps)) {
+      this.powerUps[key] = time - delta;
+      if (this.powerUps[key] <= 0) {
+        delete this.powerUps[key];
+        if (key === 'wind') {
+          this.moveSpeed = this.baseMoveSpeed;
+        } else if (key === 'wings') {
+          this.maxJumps = this.baseMaxJumps;
+        }
+      }
     }
   }
 

--- a/src/renderer.js
+++ b/src/renderer.js
@@ -360,6 +360,26 @@ export class Renderer {
       ctx.fillStyle = 'rgba(0, 0, 255, 0.5)';
       ctx.fillRect(barX, barY, barWidth * progress, barHeight);
 
+      // Level 3 special power-up icons
+      if (game.levelNumber === 3) {
+        let px = 10;
+        const py = iconY + iconSize + 8;
+        if (p.powerUps.aura) {
+          ctx.fillStyle = 'rgba(0, 0, 255, 0.5)';
+          ctx.fillRect(px, py, iconSize, iconSize);
+          px += iconSize + 4;
+        }
+        if (p.powerUps.wind) {
+          ctx.fillStyle = 'rgba(0, 255, 0, 0.5)';
+          ctx.fillRect(px, py, iconSize, iconSize);
+          px += iconSize + 4;
+        }
+        if (p.powerUps.wings) {
+          ctx.fillStyle = 'rgba(255, 0, 255, 0.5)';
+          ctx.fillRect(px, py, iconSize, iconSize);
+        }
+      }
+
       if (game.gameOver) {
         ctx.fillStyle = '#000';
         ctx.font = '24px sans-serif';


### PR DESCRIPTION
## Summary
- Introduce Aura-Shield, Wind-Hooves, and Sugar-Wings power-ups exclusive to Level 3
- Display active Level 3 power-up icons on the HUD
- Test spawning and temporary effects of new power-ups

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68af8b09dabc832caa0843659b74b5fe