### PR TITLE
Add Portal Guardian boss for Level 3 finale

### DIFF
--- a/src/entities/portalGuardian.js
+++ b/src/entities/portalGuardian.js
@@ -1,0 +1,32 @@
+export class PortalGuardian {
+  constructor(x, y, size = 1) {
+    this.x = x;
+    this.y = y;
+    this.width = size;
+    this.height = size;
+    this.baseWidth = size;
+    this.baseHeight = size;
+    this.spriteScale = 1;
+    this.hits = 0;
+    this.phase = 1;
+    this.attackPhases = ['sweep', 'charge', 'rage'];
+    this.defeated = false;
+  }
+
+  setScale(scale) {
+    this.spriteScale = scale;
+  }
+
+  update(scroll, delta) {
+    this.x -= scroll;
+  }
+
+  hit() {
+    this.hits += 1;
+    if (this.hits < 3) {
+      this.phase += 1;
+    } else {
+      this.defeated = true;
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- Introduce PortalGuardian entity with three attack phases and defeat after three hits
- Add Portal Guardian to Level 3 and open rainbow portal only after defeating the boss
- Test that Portal Guardian is unique to Level 3 and that victory requires three hits

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68af93fb209c832c916c8bfde958607f