### PR TITLE
Disable auto scroll in level 3

### DIFF
--- a/level3.test.js
+++ b/level3.test.js
@@ -29,12 +29,15 @@ test('level 3 builds entities from tile map', () => {
   assert.ok(level.enemies.length > 0);
 });
 
-// Distance travelled should increase according to the move speed.
-test('level 3 advances using move speed', () => {
+// Level 3 should remain static unless the player moves.
+test('level 3 does not auto advance without input', () => {
   const game = createStubGame({ search: '?level=3' });
-  const level = game.level;
-  level.update(1); // one second
-  assert.strictEqual(level.distance, level.getMoveSpeed());
+  const { level, player } = game;
+  game.update(1);
+  assert.strictEqual(level.distance, 0);
+  player.moveRight();
+  game.update(1);
+  assert.strictEqual(level.distance, player.moveSpeed);
 });
 
 // After travelling the entire level and clearing entities the level should end.
@@ -50,8 +53,9 @@ test('level 3 completes after level length', () => {
     level.update(FRAME);
   }
   const distanceToPortal = level.portal.x - player.x;
-  const maxSteps = Math.ceil(distanceToPortal / level.getMoveSpeed() / FRAME) + 60;
+  const maxSteps = Math.ceil(distanceToPortal / player.moveSpeed / FRAME) + 60;
   let steps = 0;
+  player.moveRight();
   while (!game.win && steps < maxSteps) {
     level.update(FRAME);
     steps++;

--- a/src/game.js
+++ b/src/game.js
@@ -216,11 +216,18 @@ export class Game {
     // Always apply gravity after a loss so the death animation completes.
     // Only skip gravity when the player has won, so they remain in place.
     const wasJumping = this.player.jumping;
+    const prevX = this.player.x;
     this.player.update(this.win ? 0 : this.gravity, this.groundY, delta);
+    const deltaX = this.player.x - prevX;
+    if (this.level.disableAutoScroll) {
+      this.player.x = prevX;
+      this.level.update(delta, deltaX);
+    } else {
+      this.level.update(delta);
+    }
     if (wasJumping && !this.player.jumping) {
       this.renderer.playSound('bounce');
     }
-    this.level.update(delta);
     if (this.gameOver && !this.player.dead && !this.win) {
       this.player.die();
     }

--- a/src/levels/level3.js
+++ b/src/levels/level3.js
@@ -202,6 +202,7 @@ export class Level3 extends BaseLevel {
     this.respawnTimer = 0;
     this.portal = null;
     this.boss = null;
+    this.disableAutoScroll = true;
     this.generateFromMap();
     this.addExclusiveEnemies();
     this.spawnPortalGuardian();
@@ -349,7 +350,7 @@ export class Level3 extends BaseLevel {
     ];
   }
 
-  update(delta) {
+  update(delta, move = this.game.player.vx * delta) {
     if (this.respawning) {
       this.respawnTimer += delta;
       if (this.respawnTimer >= 1) {
@@ -358,8 +359,7 @@ export class Level3 extends BaseLevel {
       return;
     }
 
-    const move = this.getMoveSpeed() * delta;
-    this.distance += move;
+    this.distance += move > 0 ? move : 0;
 
     const moveArr = arr => arr.forEach(e => e.update(move, delta));
     moveArr(this.platforms);

--- a/src/renderer.js
+++ b/src/renderer.js
@@ -29,6 +29,7 @@ export class Renderer {
     // Simple background clouds
     this.clouds = [];
     this.lastCloudTime = 0;
+    this.lastCloudDistance = 0;
     this.initClouds();
   }
 
@@ -155,17 +156,18 @@ export class Renderer {
       ctx.closePath();
       ctx.fill();
 
-      // Moving clouds for level 3
-      const now = typeof performance !== 'undefined' ? performance.now() : Date.now();
-      if (!this.lastCloudTime) this.lastCloudTime = now;
-      const delta = (now - this.lastCloudTime) / 1000;
-      this.lastCloudTime = now;
+      // Moving clouds for level 3 based on camera distance
+      const dist = game.level.distance;
+      const deltaDist = dist - this.lastCloudDistance;
+      this.lastCloudDistance = dist;
 
       ctx.fillStyle = '#ffffffaa';
       this.clouds.forEach(c => {
-        c.x -= c.speed * delta;
+        c.x -= c.speed * deltaDist;
         if (c.x < -c.width) {
           c.x = game.canvas.width + c.width;
+        } else if (c.x > game.canvas.width + c.width) {
+          c.x = -c.width;
         }
         const r = c.height / 2;
         ctx.beginPath();
@@ -252,7 +254,12 @@ export class Renderer {
         const delta = (now - this.lastSpriteTime) / 1000;
         this.lastSpriteTime = now;
         this.playerFrameTimer += delta;
-        const anim = this.game.gamePaused || this.game.gameOver ? 'idle' : 'run';
+        const anim =
+          this.game.gamePaused ||
+          this.game.gameOver ||
+          (this.game.level.disableAutoScroll && this.game.player.vx === 0)
+            ? 'idle'
+            : 'run';
         const frames = this.playerSprites[anim];
         if (this.playerFrameTimer >= this.frameInterval) {
           this.playerFrameTimer = 0;


### PR DESCRIPTION
## Summary
- Allow Level 3 to opt out of auto scrolling using a `disableAutoScroll` flag and player-driven movement
- Tie Level 3 background clouds to camera distance instead of time
- Add regression test ensuring Level 3 stays static until the player moves

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68afa063c7a8832ca8ad11c1d4a7ce72