### PR TITLE
feat: add platform physics to level 3

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -36,3 +36,11 @@ export const SUGAR_WINGS_DURATION = 3;
 // Effect values for Level 3 power-ups
 export const WIND_HOOVES_SPEED = 6; // temporary move speed while active
 export const SUGAR_WINGS_EXTRA_JUMPS = 1; // additional jumps granted
+
+// Platforming physics parameters for Level 3
+export const LEVEL3_ACCELERATION = 30; // ground acceleration (wu/s^2)
+export const LEVEL3_AIR_ACCELERATION = 15; // air acceleration (wu/s^2)
+export const LEVEL3_FRICTION = 15; // horizontal deceleration when no input
+export const LEVEL3_COYOTE_TIME = 0.1; // seconds after leaving a ledge you can still jump
+export const LEVEL3_JUMP_BUFFER = 0.1; // seconds a jump input is buffered before landing
+export const LEVEL3_JUMP_HOLD = 0.2; // max duration the jump button can be held for extra height

--- a/src/game.js
+++ b/src/game.js
@@ -64,6 +64,7 @@ export class Game {
         ArrowLeft: () => this.handleInput('ArrowLeft', 'down'),
       };
       const keyupMap = {
+        Space: () => this.handleInput('Space', 'up'),
         ArrowRight: () => this.handleInput('ArrowRight', 'up'),
         ArrowLeft: () => this.handleInput('ArrowLeft', 'up'),
       };
@@ -185,6 +186,11 @@ export class Game {
       if (this.levelNumber !== 3) return;
       if (type === 'down') this.player.moveLeft();
       else this.player.stopHorizontal();
+      return;
+    }
+
+    if (code === 'Space' && type === 'up') {
+      this.player.releaseJump();
       return;
     }
 

--- a/src/levels/level3.js
+++ b/src/levels/level3.js
@@ -14,6 +14,12 @@ import {
   SUGAR_WINGS_DURATION,
   WIND_HOOVES_SPEED,
   SUGAR_WINGS_EXTRA_JUMPS,
+  LEVEL3_ACCELERATION,
+  LEVEL3_AIR_ACCELERATION,
+  LEVEL3_FRICTION,
+  LEVEL3_COYOTE_TIME,
+  LEVEL3_JUMP_BUFFER,
+  LEVEL3_JUMP_HOLD,
 } from '../config.js';
 import { PowerUp, POWERUP } from '../entities/powerUp.js';
 
@@ -184,6 +190,15 @@ export class Level3 extends BaseLevel {
     super(game, random);
     this.game.player.maxJumps = 2;
     this.game.player.defaultMaxJumps = 2;
+    this.game.player.enablePlatformControls({
+      acceleration: LEVEL3_ACCELERATION,
+      airAcceleration: LEVEL3_AIR_ACCELERATION,
+      friction: LEVEL3_FRICTION,
+      coyoteTime: LEVEL3_COYOTE_TIME,
+      jumpBuffer: LEVEL3_JUMP_BUFFER,
+      jumpHold: LEVEL3_JUMP_HOLD,
+      jumpHoldForce: GRAVITY,
+    });
     this.map = MAP;
     this.tileSize = 1; // world units per tile
     this.distance = 0;


### PR DESCRIPTION
## Summary
- add configurable platformer physics constants for Level 3
- implement acceleration, friction, and buffered jumping with coyote time
- wire up key release handling and new tests for Level 3 controls

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68afa3982fb0832c83e62786608927f5