### PR TITLE
refactor: extract level3 entities

### DIFF
--- a/src/entities/block.js
+++ b/src/entities/block.js
@@ -1,0 +1,16 @@
+import { Obstacle } from '../obstacle.js';
+
+export class Block extends Obstacle {
+  constructor(x, y, size) {
+    super(x, y, size, size);
+    this.type = 'block';
+  }
+
+  setScale(scale) {
+    super.setScale(scale);
+  }
+
+  update(move, delta = 0) {
+    super.update(move);
+  }
+}

--- a/src/entities/checkpoint.js
+++ b/src/entities/checkpoint.js
@@ -1,0 +1,16 @@
+import { Obstacle } from '../obstacle.js';
+
+export class Checkpoint extends Obstacle {
+  constructor(x, groundY, size) {
+    super(x, groundY - size / 2, size, size);
+    this.type = 'checkpoint';
+  }
+
+  setScale(scale) {
+    super.setScale(scale);
+  }
+
+  update(move, delta = 0) {
+    super.update(move);
+  }
+}

--- a/src/entities/cloudPlatform.js
+++ b/src/entities/cloudPlatform.js
@@ -1,0 +1,41 @@
+import { Platform } from './platform.js';
+
+export class CloudPlatform extends Platform {
+  constructor(x, y, size) {
+    super(x, y, size);
+    this.visible = true;
+    this.stepped = false;
+    this.timer = 0;
+    this.respawn = 0;
+    this.kind = 'cloud';
+  }
+
+  onStep() {
+    this.stepped = true;
+  }
+
+  setScale(scale) {
+    super.setScale(scale);
+  }
+
+  update(move, delta = 0) {
+    super.update(move);
+    if (!this.visible) {
+      this.respawn += delta;
+      if (this.respawn >= 3) {
+        this.visible = true;
+        this.respawn = 0;
+        this.stepped = false;
+        this.timer = 0;
+      }
+      return;
+    }
+    if (this.stepped) {
+      this.timer += delta;
+      if (this.timer >= 1.2) {
+        this.visible = false;
+        this.respawn = 0;
+      }
+    }
+  }
+}

--- a/src/entities/fallingPlatform.js
+++ b/src/entities/fallingPlatform.js
@@ -1,0 +1,43 @@
+import { Platform } from './platform.js';
+import { GRAVITY } from '../config.js';
+
+export class FallingPlatform extends Platform {
+  constructor(x, y, size, groundY) {
+    super(x, y, size);
+    this.groundY = groundY;
+    this.stepped = false;
+    this.shake = 0;
+    this.falling = false;
+    this.vy = 0;
+    this.visible = true;
+    this.kind = 'falling';
+  }
+
+  onStep() {
+    if (!this.stepped) {
+      this.stepped = true;
+      this.shake = 0;
+    }
+  }
+
+  setScale(scale) {
+    super.setScale(scale);
+  }
+
+  update(move, delta = 0) {
+    super.update(move);
+    if (this.stepped && !this.falling) {
+      this.shake += delta;
+      if (this.shake >= 0.3) {
+        this.falling = true;
+      }
+    }
+    if (this.falling) {
+      this.vy += GRAVITY * delta;
+      this.y += this.vy * delta;
+      if (this.y - this.height / 2 > this.groundY + 2) {
+        this.visible = false;
+      }
+    }
+  }
+}

--- a/src/entities/pipe.js
+++ b/src/entities/pipe.js
@@ -1,0 +1,17 @@
+import { Obstacle } from '../obstacle.js';
+
+export class Pipe extends Obstacle {
+  constructor(x, groundY, size) {
+    // Pipes are two tiles tall and rest on the ground
+    super(x, groundY - size, size, size * 2);
+    this.type = 'pipe';
+  }
+
+  setScale(scale) {
+    super.setScale(scale);
+  }
+
+  update(move, delta = 0) {
+    super.update(move);
+  }
+}

--- a/src/entities/platform.js
+++ b/src/entities/platform.js
@@ -1,0 +1,16 @@
+import { Obstacle } from '../obstacle.js';
+
+export class Platform extends Obstacle {
+  constructor(x, y, size) {
+    super(x, y, size, size);
+    this.type = 'platform';
+  }
+
+  setScale(scale) {
+    super.setScale(scale);
+  }
+
+  update(move, delta = 0) {
+    super.update(move);
+  }
+}

--- a/src/entities/portal.js
+++ b/src/entities/portal.js
@@ -1,0 +1,17 @@
+import { Obstacle } from '../obstacle.js';
+
+export class Portal extends Obstacle {
+  constructor(x, groundY, size) {
+    super(x, groundY - size, size, size * 2);
+    this.type = 'portal';
+    this.open = false;
+  }
+
+  setScale(scale) {
+    super.setScale(scale);
+  }
+
+  update(move, delta = 0) {
+    super.update(move);
+  }
+}

--- a/src/entities/star.js
+++ b/src/entities/star.js
@@ -1,0 +1,16 @@
+import { Obstacle } from '../obstacle.js';
+
+export class Star extends Obstacle {
+  constructor(x, y, size) {
+    super(x, y, size, size);
+    this.type = 'star';
+  }
+
+  setScale(scale) {
+    super.setScale(scale);
+  }
+
+  update(move, delta = 0) {
+    super.update(move);
+  }
+}

--- a/src/levels/level3.js
+++ b/src/levels/level3.js
@@ -1,10 +1,17 @@
 import { BaseLevel } from './baseLevel.js';
-import { Obstacle } from '../obstacle.js';
 import { Goomba } from '../entities/goomba.js';
 import { ShadowCrow } from '../entities/shadowCrow.js';
 import { RhombusSprite } from '../entities/rhombusSprite.js';
 import { ThornGuard } from '../entities/thornGuard.js';
 import { PortalGuardian } from '../entities/portalGuardian.js';
+import { Platform } from '../entities/platform.js';
+import { CloudPlatform } from '../entities/cloudPlatform.js';
+import { FallingPlatform } from '../entities/fallingPlatform.js';
+import { Pipe } from '../entities/pipe.js';
+import { Block } from '../entities/block.js';
+import { Star } from '../entities/star.js';
+import { Checkpoint } from '../entities/checkpoint.js';
+import { Portal } from '../entities/portal.js';
 import { isColliding, isLandingOn } from '../../collision.js';
 import {
   JUMP_VELOCITY,
@@ -67,122 +74,6 @@ row1[MAP_WIDTH - 5] = TILE.PORTAL;
 
 const MAP = [ground, row1, row2];
 
-class Platform extends Obstacle {
-  constructor(x, y, size) {
-    super(x, y, size, size);
-    this.type = 'platform';
-  }
-}
-
-class CloudPlatform extends Platform {
-  constructor(x, y, size) {
-    super(x, y, size);
-    this.visible = true;
-    this.stepped = false;
-    this.timer = 0;
-    this.respawn = 0;
-    this.kind = 'cloud';
-  }
-
-  onStep() {
-    this.stepped = true;
-  }
-
-  update(move, delta = 0) {
-    super.update(move);
-    if (!this.visible) {
-      this.respawn += delta;
-      if (this.respawn >= 3) {
-        this.visible = true;
-        this.respawn = 0;
-        this.stepped = false;
-        this.timer = 0;
-      }
-      return;
-    }
-    if (this.stepped) {
-      this.timer += delta;
-      if (this.timer >= 1.2) {
-        this.visible = false;
-        this.respawn = 0;
-      }
-    }
-  }
-}
-
-class FallingPlatform extends Platform {
-  constructor(x, y, size, groundY) {
-    super(x, y, size);
-    this.groundY = groundY;
-    this.stepped = false;
-    this.shake = 0;
-    this.falling = false;
-    this.vy = 0;
-    this.visible = true;
-    this.kind = 'falling';
-  }
-
-  onStep() {
-    if (!this.stepped) {
-      this.stepped = true;
-      this.shake = 0;
-    }
-  }
-
-  update(move, delta = 0) {
-    super.update(move);
-    if (this.stepped && !this.falling) {
-      this.shake += delta;
-      if (this.shake >= 0.3) {
-        this.falling = true;
-      }
-    }
-    if (this.falling) {
-      this.vy += GRAVITY * delta;
-      this.y += this.vy * delta;
-      if (this.y - this.height / 2 > this.groundY + 2) {
-        this.visible = false;
-      }
-    }
-  }
-}
-
-class Pipe extends Obstacle {
-  constructor(x, groundY, size) {
-    // Pipes are two tiles tall and rest on the ground
-    super(x, groundY - size, size, size * 2);
-    this.type = 'pipe';
-  }
-}
-
-class Block extends Obstacle {
-  constructor(x, y, size) {
-    super(x, y, size, size);
-    this.type = 'block';
-  }
-}
-
-class Star extends Obstacle {
-  constructor(x, y, size) {
-    super(x, y, size, size);
-    this.type = 'star';
-  }
-}
-
-class Checkpoint extends Obstacle {
-  constructor(x, groundY, size) {
-    super(x, groundY - size / 2, size, size);
-    this.type = 'checkpoint';
-  }
-}
-
-class Portal extends Obstacle {
-  constructor(x, groundY, size) {
-    super(x, groundY - size, size, size * 2);
-    this.type = 'portal';
-    this.open = false;
-  }
-}
 
 // Level 3 - Unicornolandia converted to a tile-based platform section
 export class Level3 extends BaseLevel {


### PR DESCRIPTION
## Summary
- extract Level 3 obstacle classes into individual entity modules
- use imports for platforms, pipes, blocks, collectibles, and portal in Level3

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b01fd88e48832c9e980e459a6ad115