### PR TITLE
Expose explicit platform tile columns for Level 3

### DIFF
--- a/src/levels/level3.js
+++ b/src/levels/level3.js
@@ -69,13 +69,18 @@ const row1 = Array(MAP_WIDTH).fill(TILE.EMPTY);
 const row2 = Array(MAP_WIDTH).fill(TILE.EMPTY);
 
 // Ability section - small platforms to practice jumping
+const CLOUD_PLATFORM_COLUMNS = [];
+const FALLING_PLATFORM_COLUMNS = [];
 for (
   let c = ABILITY_SECTION_START, i = 0;
   c < ABILITY_SECTION_END;
   c += 2, i++
 ) {
-  row1[c] = i % 2 === 0 ? TILE.CLOUD_PLATFORM : TILE.FALLING_PLATFORM;
+  if (i % 2 === 0) CLOUD_PLATFORM_COLUMNS.push(c);
+  else FALLING_PLATFORM_COLUMNS.push(c);
 }
+CLOUD_PLATFORM_COLUMNS.forEach(c => (row1[c] = TILE.CLOUD_PLATFORM));
+FALLING_PLATFORM_COLUMNS.forEach(c => (row1[c] = TILE.FALLING_PLATFORM));
 
 // Secret star path high in the sky
 for (let c = SECRET_STAR_START; c < SECRET_STAR_END; c++) row2[c] = TILE.STAR;


### PR DESCRIPTION
## Summary
- Refactor Level 3 map generation to declare cloud and falling platform columns explicitly
- Map tile IDs to platform types when building the Level 3 layout

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_68b0414463f0832c94e7dbb643edbd3e