### PR TITLE
Refactor Level 3 tests for clarity and reuse

### DIFF
--- a/level3-mechanics.test.js
+++ b/level3-mechanics.test.js
@@ -1,6 +1,6 @@
 import test, { describe } from 'node:test';
 import assert from 'node:assert';
-import { createLevel3Game, FRAME } from './level3TestHelpers.js';
+import { withLevel3, FRAME } from './level3TestHelpers.js';
 import { createStubGame } from './testHelpers.js';
 import { LEVEL3_MAP } from './src/levels/level3.js';
 import { JUMP_VELOCITY, SHIELD_GRACE } from './src/config.js';
@@ -12,209 +12,204 @@ import { Obstacle } from './src/obstacle.js';
 describe('Level 3 mechanics', () => {
   describe('level basics', () => {
     test('level 3 builds entities from tile map', () => {
-      const game = createLevel3Game({ skipLevelUpdate: true });
-      const level = game.level;
-      assert.deepStrictEqual(level.map, LEVEL3_MAP);
-      assert.ok(level.platforms.length > 0);
-      assert.ok(level.pipes.length > 0);
-      assert.ok(level.enemies.length > 0);
+      withLevel3({ skipLevelUpdate: true }, ({ level }) => {
+        assert.deepStrictEqual(level.map, LEVEL3_MAP);
+        assert.ok(level.platforms.length > 0);
+        assert.ok(level.pipes.length > 0);
+        assert.ok(level.enemies.length > 0);
+      });
     });
 
     test('level 3 does not auto advance without input', () => {
-      const game = createLevel3Game();
-      const { level, player } = game;
-      game.update(1);
-      assert.strictEqual(level.distance, 0);
-      player.moveRight();
-      game.update(1);
-      assert.ok(level.distance > 0);
+      withLevel3({}, ({ game, level, player }) => {
+        game.update(1);
+        assert.strictEqual(level.distance, 0);
+        player.moveRight();
+        game.update(1);
+        assert.ok(level.distance > 0);
+      });
     });
 
     test('level 3 completes after level length', () => {
-      const game = createLevel3Game();
-      const level = game.level;
-      const boss = level.boss;
-      const player = game.player;
-      for (let i = 0; i < 3; i++) {
-        player.x = boss.x;
-        player.y = boss.y - boss.height / 2 - player.height / 2 + 0.01;
+      withLevel3({}, ({ game, level, player }) => {
+        const boss = level.boss;
+        for (let i = 0; i < 3; i++) {
+          player.x = boss.x;
+          player.y = boss.y - boss.height / 2 - player.height / 2 + 0.01;
+          player.vy = 1;
+          level.update(FRAME);
+        }
+        player.x = level.portal.x;
+        player.y = level.portal.y - level.portal.height / 2 - player.height / 2 + 0.01;
         player.vy = 1;
         level.update(FRAME);
-      }
-      player.x = level.portal.x;
-      player.y = level.portal.y - level.portal.height / 2 - player.height / 2 + 0.01;
-      player.vy = 1;
-      level.update(FRAME);
-      assert.ok(game.win);
+        assert.ok(game.win);
+      });
     });
 
     test('level 3 maps space to jump', () => {
-      const game = createLevel3Game({ skipLevelUpdate: true });
-      const player = game.player;
-      game.handleInput();
-      game.update(FRAME);
-      assert.strictEqual(player.jumping, true);
-      assert.strictEqual(player.shieldActive, false);
+      withLevel3({ skipLevelUpdate: true }, ({ game, player }) => {
+        game.handleInput();
+        game.update(FRAME);
+        assert.strictEqual(player.jumping, true);
+        assert.strictEqual(player.shieldActive, false);
+      });
     });
 
     test('player stops within 0.4s after releasing move', () => {
-      const game = createLevel3Game({ skipLevelUpdate: true });
-      const { player } = game;
-      player.moveRight();
-      for (let i = 0; i < 30; i++) game.update(FRAME);
-      player.stopHorizontal();
-      for (let i = 0; i < 24; i++) game.update(FRAME);
-      assert.ok(Math.abs(player.vx) < 0.01);
+      withLevel3({ skipLevelUpdate: true }, ({ game, player }) => {
+        player.moveRight();
+        for (let i = 0; i < 30; i++) game.update(FRAME);
+        player.stopHorizontal();
+        for (let i = 0; i < 24; i++) game.update(FRAME);
+        assert.ok(Math.abs(player.vx) < 0.01);
+      });
     });
 
     test('level 3 duration is between 90 and 150 seconds', () => {
-      const game = createLevel3Game({ skipLevelUpdate: true });
-      const level = game.level;
-      const duration = level.levelLength / level.getMoveSpeed();
-      assert.ok(duration >= 90 && duration <= 150);
+      withLevel3({ skipLevelUpdate: true }, ({ level }) => {
+        const duration = level.levelLength / level.getMoveSpeed();
+        assert.ok(duration >= 90 && duration <= 150);
+      });
     });
   });
 
   describe('jumping mechanics', () => {
     test('coyote time allows late jumps', () => {
-      const game = createLevel3Game();
-      const { level, player } = game;
-      level.getMoveSpeed = () => 0;
-      const platform = { x: player.x, y: player.y - 1, width: 1, height: 0.2, visible: true, update: () => {} };
-      level.platforms = [platform];
-      level.obstacles = [platform];
-      player.y = platform.y - platform.height / 2 - player.height / 2;
-      player.vy = 0;
-      game.update(FRAME);
-      level.platforms = [];
-      level.obstacles = [];
-      game.update(FRAME);
-      game.handleInput();
-      game.update(FRAME);
-      assert.ok(player.jumping);
+      withLevel3({}, ({ game, level, player }) => {
+        level.getMoveSpeed = () => 0;
+        const platform = { x: player.x, y: player.y - 1, width: 1, height: 0.2, visible: true, update: () => {} };
+        level.platforms = [platform];
+        level.obstacles = [platform];
+        player.y = platform.y - platform.height / 2 - player.height / 2;
+        player.vy = 0;
+        game.update(FRAME);
+        level.platforms = [];
+        level.obstacles = [];
+        game.update(FRAME);
+        game.handleInput();
+        game.update(FRAME);
+        assert.ok(player.jumping);
+      });
     });
 
     test('jump buffer triggers jump on landing', () => {
-      const game = createLevel3Game();
-      const { player } = game;
-      game.level.getMoveSpeed = () => 0;
-      player.y = game.groundY - player.height / 2 - 1;
-      player.vy = 0;
-      player.jumping = true;
-      for (let i = 0; i < 30; i++) {
-        if (i === 20) game.handleInput();
-        game.update(FRAME);
-      }
-      assert.ok(player.jumping);
-      assert.ok(player.y < game.groundY - player.height / 2);
+      withLevel3({}, ({ game, player }) => {
+        game.level.getMoveSpeed = () => 0;
+        player.y = game.groundY - player.height / 2 - 1;
+        player.vy = 0;
+        player.jumping = true;
+        for (let i = 0; i < 30; i++) {
+          if (i === 20) game.handleInput();
+          game.update(FRAME);
+        }
+        assert.ok(player.jumping);
+        assert.ok(player.y < game.groundY - player.height / 2);
+      });
     });
 
     test('player can double jump in level 3', () => {
-      const game = createLevel3Game({ skipLevelUpdate: true });
-      const player = game.player;
-      player.jump();
-      game.update(FRAME);
-      player.jump();
-      game.update(FRAME);
-      assert.strictEqual(player.jumpCount, 2);
-      assert.strictEqual(player.vy, JUMP_VELOCITY);
+      withLevel3({ skipLevelUpdate: true }, ({ game, player }) => {
+        player.jump();
+        game.update(FRAME);
+        player.jump();
+        game.update(FRAME);
+        assert.strictEqual(player.jumpCount, 2);
+        assert.strictEqual(player.vy, JUMP_VELOCITY);
+      });
     });
 
     test('player cannot triple jump in level 3', () => {
-      const game = createLevel3Game({ skipLevelUpdate: true });
-      const player = game.player;
-      player.jump();
-      game.update(FRAME);
-      player.jump();
-      game.update(FRAME);
-      player.jump();
-      assert.strictEqual(player.jumpCount, 2);
+      withLevel3({ skipLevelUpdate: true }, ({ game, player }) => {
+        player.jump();
+        game.update(FRAME);
+        player.jump();
+        game.update(FRAME);
+        player.jump();
+        assert.strictEqual(player.jumpCount, 2);
+      });
     });
   });
 
   describe('platform interactions', () => {
     test('player safely bumps into platform side', () => {
-      const game = createLevel3Game();
-      const level = game.level;
-      level.getMoveSpeed = () => 0;
-      const { player } = game;
-      const platform = {
-        x: player.x + 1,
-        y: player.y,
-        width: 1,
-        height: 0.2,
-        visible: true,
-        update: () => {},
-      };
-      level.platforms = [platform];
-      level.obstacles = [platform];
-      player.x = platform.x - platform.width / 2 - player.width / 2 + 0.1;
-      player.vy = 0;
-      level.update(FRAME);
-      const expectedX = platform.x - platform.width / 2 - player.width / 2;
-      assert.ok(Math.abs(player.x - expectedX) < 1e-6);
-      assert.strictEqual(game.gameOver, false);
+      withLevel3({}, ({ game, level, player }) => {
+        level.getMoveSpeed = () => 0;
+        const platform = {
+          x: player.x + 1,
+          y: player.y,
+          width: 1,
+          height: 0.2,
+          visible: true,
+          update: () => {},
+        };
+        level.platforms = [platform];
+        level.obstacles = [platform];
+        player.x = platform.x - platform.width / 2 - player.width / 2 + 0.1;
+        player.vy = 0;
+        level.update(FRAME);
+        const expectedX = platform.x - platform.width / 2 - player.width / 2;
+        assert.ok(Math.abs(player.x - expectedX) < 1e-6);
+        assert.strictEqual(game.gameOver, false);
+      });
     });
 
     test('player safely touches platform bottom', () => {
-      const game = createLevel3Game();
-      const level = game.level;
-      level.getMoveSpeed = () => 0;
-      const { player } = game;
-      const startY = player.y;
-      const platform = {
-        x: player.x,
-        y: startY - 1,
-        width: 1,
-        height: 0.2,
-        visible: true,
-        update: () => {},
-      };
-      level.platforms = [platform];
-      level.obstacles = [platform];
-      player.y = platform.y + platform.height / 2 + player.height / 2 - 0.05;
-      player.vy = -1;
-      level.update(FRAME);
-      const expectedY = platform.y + platform.height / 2 + player.height / 2;
-      assert.ok(Math.abs(player.y - expectedY) < 1e-6);
-      assert.strictEqual(game.gameOver, false);
+      withLevel3({}, ({ game, level, player }) => {
+        level.getMoveSpeed = () => 0;
+        const startY = player.y;
+        const platform = {
+          x: player.x,
+          y: startY - 1,
+          width: 1,
+          height: 0.2,
+          visible: true,
+          update: () => {},
+        };
+        level.platforms = [platform];
+        level.obstacles = [platform];
+        player.y = platform.y + platform.height / 2 + player.height / 2 - 0.05;
+        player.vy = -1;
+        level.update(FRAME);
+        const expectedY = platform.y + platform.height / 2 + player.height / 2;
+        assert.ok(Math.abs(player.y - expectedY) < 1e-6);
+        assert.strictEqual(game.gameOver, false);
+      });
     });
 
     test('cloud platform disappears then respawns', () => {
-      const game = createLevel3Game();
-      const level = game.level;
-      level.getMoveSpeed = () => 0;
-      const cloud = level.platforms.find(p => p.kind === 'cloud');
-      assert.ok(cloud);
-      const player = game.player;
-      cloud.x = player.x;
-      cloud.y = player.y - 1;
-      player.y = cloud.y - cloud.height / 2 - player.height / 2 + 0.01;
-      player.vy = 0.1;
-      game.update(FRAME);
-      for (let i = 0; i < Math.ceil(1.2 / FRAME) + 1; i++) game.update(FRAME);
-      assert.strictEqual(cloud.visible, false);
-      for (let i = 0; i < Math.ceil(3 / FRAME); i++) game.update(FRAME);
-      assert.strictEqual(cloud.visible, true);
+      withLevel3({}, ({ game, level, player }) => {
+        level.getMoveSpeed = () => 0;
+        const cloud = level.platforms.find(p => p.kind === 'cloud');
+        assert.ok(cloud);
+        cloud.x = player.x;
+        cloud.y = player.y - 1;
+        player.y = cloud.y - cloud.height / 2 - player.height / 2 + 0.01;
+        player.vy = 0.1;
+        game.update(FRAME);
+        for (let i = 0; i < Math.ceil(1.2 / FRAME) + 1; i++) game.update(FRAME);
+        assert.strictEqual(cloud.visible, false);
+        for (let i = 0; i < Math.ceil(3 / FRAME); i++) game.update(FRAME);
+        assert.strictEqual(cloud.visible, true);
+      });
     });
 
     test('falling platform drops after shaking', () => {
-      const game = createLevel3Game();
-      const level = game.level;
-      level.getMoveSpeed = () => 0;
-      const falling = level.platforms.find(p => p.kind === 'falling');
-      assert.ok(falling);
-      const player = game.player;
-      falling.x = player.x;
-      falling.y = player.y - 1;
-      player.y = falling.y - falling.height / 2 - player.height / 2 + 0.01;
-      player.vy = 0.1;
-      game.update(FRAME);
-      for (let i = 0; i < Math.ceil(0.3 / FRAME) + 1; i++) game.update(FRAME);
-      const yBefore = falling.y;
-      game.update(FRAME);
-      assert.ok(falling.falling);
-      assert.ok(falling.y > yBefore);
+      withLevel3({}, ({ game, level, player }) => {
+        level.getMoveSpeed = () => 0;
+        const falling = level.platforms.find(p => p.kind === 'falling');
+        assert.ok(falling);
+        falling.x = player.x;
+        falling.y = player.y - 1;
+        player.y = falling.y - falling.height / 2 - player.height / 2 + 0.01;
+        player.vy = 0.1;
+        game.update(FRAME);
+        for (let i = 0; i < Math.ceil(0.3 / FRAME) + 1; i++) game.update(FRAME);
+        const yBefore = falling.y;
+        game.update(FRAME);
+        assert.ok(falling.falling);
+        assert.ok(falling.y > yBefore);
+      });
     });
 
     test('special platforms exist only in level 3', () => {
@@ -222,34 +217,35 @@ describe('Level 3 mechanics', () => {
       assert.ok(!g1.level.platforms || g1.level.platforms.length === 0);
       const g2 = createStubGame({ search: '?level=2', skipLevelUpdate: true });
       assert.ok(!g2.level.platforms || g2.level.platforms.length === 0);
-      const g3 = createLevel3Game({ skipLevelUpdate: true });
-      assert.ok(g3.level.platforms.length > 0);
+      withLevel3({ skipLevelUpdate: true }, ({ level }) => {
+        assert.ok(level.platforms.length > 0);
+      });
     });
   });
 
   describe('collectibles and checkpoints', () => {
     test('level 3 has a secret of five stars', () => {
-      const game = createLevel3Game({ skipLevelUpdate: true });
-      const level = game.level;
-      assert.strictEqual(level.stars.length, 5);
+      withLevel3({ skipLevelUpdate: true }, ({ level }) => {
+        assert.strictEqual(level.stars.length, 5);
+      });
     });
 
     test('collecting a star increases star count', () => {
-      const game = createLevel3Game();
-      const level = game.level;
-      const star = level.stars[0];
-      star.x = game.player.x;
-      star.y = game.player.y;
-      level.update(FRAME);
-      assert.strictEqual(game.stars, 1);
-      assert.strictEqual(level.stars.length, 4);
+      withLevel3({}, ({ game, level }) => {
+        const star = level.stars[0];
+        star.x = game.player.x;
+        star.y = game.player.y;
+        level.update(FRAME);
+        assert.strictEqual(game.stars, 1);
+        assert.strictEqual(level.stars.length, 4);
+      });
     });
 
     test('checkpoint and portal are unique to level 3', () => {
-      const game = createLevel3Game({ skipLevelUpdate: true });
-      const level = game.level;
-      assert.ok(level.checkpoint);
-      assert.ok(level.portal);
+      withLevel3({ skipLevelUpdate: true }, ({ level }) => {
+        assert.ok(level.checkpoint);
+        assert.ok(level.portal);
+      });
       const game1 = createStubGame({ search: '?level=1', skipLevelUpdate: true });
       assert.ok(!game1.level.stars || game1.level.stars.length === 0);
       const game2 = createStubGame({ search: '?level=2', skipLevelUpdate: true });
@@ -257,28 +253,27 @@ describe('Level 3 mechanics', () => {
     });
 
     test('player respawns at checkpoint in level 3', () => {
-      const game = createLevel3Game();
-      const level = game.level;
-      const player = game.player;
-      const cp = level.checkpoint;
-      player.x = cp.x;
-      player.y = game.groundY - player.height / 2;
-      level.update(FRAME);
-      assert.ok(level.checkpointReached);
-      const enemy = new Goomba(player.x, player.y, 1);
-      level.enemies = [enemy];
-      level.obstacles = [
-        ...level.platforms.filter(p => p.visible),
-        ...level.pipes,
-        ...level.blocks,
-        enemy,
-      ];
-      level.update(FRAME);
-      assert.strictEqual(level.respawning, true);
-      for (let i = 0; i < Math.ceil(1 / FRAME) + 1; i++) level.update(FRAME);
-      assert.strictEqual(level.respawning, false);
-      assert.strictEqual(game.gameOver, false);
-      assert.ok(Math.abs(player.x - level.respawnPoint.x) < 1e-6);
+      withLevel3({}, ({ game, level, player }) => {
+        const cp = level.checkpoint;
+        player.x = cp.x;
+        player.y = game.groundY - player.height / 2;
+        level.update(FRAME);
+        assert.ok(level.checkpointReached);
+        const enemy = new Goomba(player.x, player.y, 1);
+        level.enemies = [enemy];
+        level.obstacles = [
+          ...level.platforms.filter(p => p.visible),
+          ...level.pipes,
+          ...level.blocks,
+          enemy,
+        ];
+        level.update(FRAME);
+        assert.strictEqual(level.respawning, true);
+        for (let i = 0; i < Math.ceil(1 / FRAME) + 1; i++) level.update(FRAME);
+        assert.strictEqual(level.respawning, false);
+        assert.strictEqual(game.gameOver, false);
+        assert.ok(Math.abs(player.x - level.respawnPoint.x) < 1e-6);
+      });
     });
 
     test('other levels do not respawn on death', () => {

--- a/level3-powerups.test.js
+++ b/level3-powerups.test.js
@@ -1,6 +1,6 @@
 import test, { describe } from 'node:test';
 import assert from 'node:assert';
-import { createLevel3Game, FRAME } from './level3TestHelpers.js';
+import { withLevel3, FRAME } from './level3TestHelpers.js';
 import { createStubGame } from './testHelpers.js';
 import {
   AURA_SHIELD_DURATION,
@@ -12,41 +12,45 @@ import {
 // Power-up related tests for Level 3
 
 describe('Level 3 power-ups', () => {
-  test('special power-ups appear only in level 3', () => {
-    const g1 = createStubGame({ search: '?level=1', skipLevelUpdate: true });
-    const g2 = createStubGame({ search: '?level=2', skipLevelUpdate: true });
-    const g3 = createLevel3Game({ skipLevelUpdate: true });
-    assert.ok(!g1.level.powerUps || g1.level.powerUps.length === 0);
-    assert.ok(!g2.level.powerUps || g2.level.powerUps.length === 0);
-    assert.strictEqual(g3.level.powerUps.length, 3);
+  describe('availability', () => {
+    test('special power-ups appear only in level 3', () => {
+      const g1 = createStubGame({ search: '?level=1', skipLevelUpdate: true });
+      const g2 = createStubGame({ search: '?level=2', skipLevelUpdate: true });
+      withLevel3({ skipLevelUpdate: true }, ({ level }) => {
+        assert.ok(!g1.level.powerUps || g1.level.powerUps.length === 0);
+        assert.ok(!g2.level.powerUps || g2.level.powerUps.length === 0);
+        assert.strictEqual(level.powerUps.length, 3);
+      });
+    });
   });
 
-  test('power-ups grant temporary effects', () => {
-    const game = createLevel3Game();
-    const level = game.level;
-    level.getMoveSpeed = () => 0;
-    const player = game.player;
-    const [aura, hooves, wings] = level.powerUps;
+  describe('effects', () => {
+    test('power-ups grant temporary effects', () => {
+      withLevel3({}, ({ game, level, player }) => {
+        level.getMoveSpeed = () => 0;
+        const [aura, hooves, wings] = level.powerUps;
 
-    aura.x = player.x;
-    aura.y = player.y;
-    game.update(FRAME);
-    assert.ok(player.shieldActive);
-    for (let i = 0; i < Math.ceil(AURA_SHIELD_DURATION / FRAME) + 1; i++) game.update(FRAME);
-    assert.ok(!player.shieldActive);
+        aura.x = player.x;
+        aura.y = player.y;
+        game.update(FRAME);
+        assert.ok(player.shieldActive);
+        for (let i = 0; i < Math.ceil(AURA_SHIELD_DURATION / FRAME) + 1; i++) game.update(FRAME);
+        assert.ok(!player.shieldActive);
 
-    hooves.x = player.x;
-    hooves.y = player.y;
-    game.update(FRAME);
-    assert.strictEqual(player.moveSpeed, WIND_HOOVES_SPEED);
-    for (let i = 0; i < Math.ceil(WIND_HOOVES_DURATION / FRAME) + 1; i++) game.update(FRAME);
-    assert.strictEqual(player.moveSpeed, player.defaultMoveSpeed);
+        hooves.x = player.x;
+        hooves.y = player.y;
+        game.update(FRAME);
+        assert.strictEqual(player.moveSpeed, WIND_HOOVES_SPEED);
+        for (let i = 0; i < Math.ceil(WIND_HOOVES_DURATION / FRAME) + 1; i++) game.update(FRAME);
+        assert.strictEqual(player.moveSpeed, player.defaultMoveSpeed);
 
-    wings.x = player.x;
-    wings.y = player.y;
-    game.update(FRAME);
-    assert.strictEqual(player.maxJumps, player.defaultMaxJumps + 1);
-    for (let i = 0; i < Math.ceil(SUGAR_WINGS_DURATION / FRAME) + 1; i++) game.update(FRAME);
-    assert.strictEqual(player.maxJumps, player.defaultMaxJumps);
+        wings.x = player.x;
+        wings.y = player.y;
+        game.update(FRAME);
+        assert.strictEqual(player.maxJumps, player.defaultMaxJumps + 1);
+        for (let i = 0; i < Math.ceil(SUGAR_WINGS_DURATION / FRAME) + 1; i++) game.update(FRAME);
+        assert.strictEqual(player.maxJumps, player.defaultMaxJumps);
+      });
+    });
   });
 });

--- a/level3TestHelpers.js
+++ b/level3TestHelpers.js
@@ -5,3 +5,24 @@ export const FRAME = 1 / 60;
 export function createLevel3Game({ skipLevelUpdate = false } = {}) {
   return createStubGame({ search: '?level=3', skipLevelUpdate });
 }
+
+// Shared helpers for Level 3 tests
+export function setupLevel3(options) {
+  const game = createLevel3Game(options);
+  return { game, level: game.level, player: game.player };
+}
+
+export function teardownLevel3(game) {
+  // Currently no special teardown is required but this ensures
+  // symmetry with setup and provides a single place for future cleanup.
+  void game;
+}
+
+export function withLevel3(options, fn) {
+  const { game, level, player } = setupLevel3(options);
+  try {
+    return fn({ game, level, player });
+  } finally {
+    teardownLevel3(game);
+  }
+}


### PR DESCRIPTION
## Summary
- add Level 3 test helpers providing setup/teardown and withLevel3 wrapper
- group power-up tests by availability and effects
- streamline Level 3 test files to use shared helpers for mechanics, enemies, and power-ups

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b04891c068832ca56fce81debfa5a6