### PR TITLE
Add test environment cleanup

### DIFF
--- a/coins.test.js
+++ b/coins.test.js
@@ -1,11 +1,13 @@
 import test from 'node:test';
 import assert from 'node:assert';
-import { createStubGame } from './testHelpers.js';
+import { createStubGame, destroyStubGame } from './testHelpers.js';
 import { Obstacle } from './src/obstacle.js';
 import { Level2 } from './src/levels/level2.js';
 import { LEVEL_UP_SCORE } from './src/config.js';
 
 const FRAME = 1 / 60;
+
+test.after(() => destroyStubGame());
 
 test('awards coin for passed obstacle and preserves coins in level 2', () => {
   const game = createStubGame();

--- a/deterministic.test.js
+++ b/deterministic.test.js
@@ -1,8 +1,10 @@
 import test from 'node:test';
 import assert from 'node:assert';
-import { createStubGame } from './testHelpers.js';
+import { createStubGame, destroyStubGame } from './testHelpers.js';
 
 const FRAME = 1 / 60;
+
+test.after(() => destroyStubGame());
 
 function seededRandom(seed) {
   let s = seed;

--- a/earlyJump.test.js
+++ b/earlyJump.test.js
@@ -1,8 +1,10 @@
 import test from 'node:test';
 import assert from 'node:assert';
-import { createStubGame } from './testHelpers.js';
+import { createStubGame, destroyStubGame } from './testHelpers.js';
 
 const FRAME = 1 / 60;
+
+test.after(() => destroyStubGame());
 
 // Ensure that jumping early over an obstacle no longer causes a collision
 // once the obstacle has been cleared.

--- a/fixedTimestep.test.js
+++ b/fixedTimestep.test.js
@@ -1,8 +1,10 @@
 import test from 'node:test';
 import assert from 'node:assert';
-import { createStubGame } from './testHelpers.js';
+import { createStubGame, destroyStubGame } from './testHelpers.js';
 
 const STEP = 1 / 60;
+
+test.after(() => destroyStubGame());
 
 // Verify that the main game loop advances the simulation using a fixed 60 Hz
 // timestep regardless of the frame delta provided.

--- a/game.test.js
+++ b/game.test.js
@@ -1,12 +1,14 @@
 import test from 'node:test';
 import assert from 'node:assert';
-import { createStubGame } from './testHelpers.js';
+import { createStubGame, destroyStubGame } from './testHelpers.js';
 import { Game } from './src/game.js';
 import { Level2 } from './src/levels/level2.js';
 import { Level3 } from './src/levels/level3.js';
 import { LEVEL_UP_SCORE } from './src/config.js';
 
 const FRAME = 1 / 60;
+
+test.after(() => destroyStubGame());
 
 test('advances to level 2 after reaching threshold points', () => {
   const game = createStubGame({ skipLevelUpdate: true });

--- a/highScore.test.js
+++ b/highScore.test.js
@@ -1,8 +1,11 @@
 import test from 'node:test';
 import assert from 'node:assert';
-import { createStubGame } from './testHelpers.js';
+import { createStubGame, destroyStubGame } from './testHelpers.js';
+
+test.after(() => destroyStubGame());
 
 test('reads high score from localStorage', () => {
+  createStubGame({ skipLevelUpdate: true });
   localStorage.clear();
   localStorage.setItem('highScore', '123');
   const game = createStubGame({ skipLevelUpdate: true });
@@ -10,6 +13,7 @@ test('reads high score from localStorage', () => {
 });
 
 test('updates high score and persists across reset and new game', () => {
+  createStubGame({ skipLevelUpdate: true });
   localStorage.clear();
   const game = createStubGame({ skipLevelUpdate: true });
   game.score = 50;

--- a/jumpScale.test.js
+++ b/jumpScale.test.js
@@ -1,6 +1,6 @@
 import test from 'node:test';
 import assert from 'node:assert';
-import { createStubGame } from './testHelpers.js';
+import { createStubGame, destroyStubGame } from './testHelpers.js';
 import { JUMP_VELOCITY, GRAVITY } from './src/config.js';
 
 const FRAME = 1 / 60;
@@ -19,6 +19,8 @@ function simulate(innerWidth) {
   }
   return { finalY: player.y, minY };
 }
+
+test.after(() => destroyStubGame());
 
 test('jump height and timing unaffected by sprite scale', () => {
   const normal = simulate(1600); // scale ~1

--- a/landing.test.js
+++ b/landing.test.js
@@ -1,9 +1,11 @@
 import test from 'node:test';
 import assert from 'node:assert';
-import { createStubGame } from './testHelpers.js';
+import { createStubGame, destroyStubGame } from './testHelpers.js';
 import { JUMP_VELOCITY, GRAVITY } from './src/config.js';
 
 const FRAME = 1 / 60;
+
+test.after(() => destroyStubGame());
 
 test('player lands within expected time after jumping', () => {
   const game = createStubGame({ skipLevelUpdate: true });

--- a/level1.test.js
+++ b/level1.test.js
@@ -1,6 +1,8 @@
 import test from 'node:test';
 import assert from 'node:assert';
-import { createStubGame } from './testHelpers.js';
+import { createStubGame, destroyStubGame } from './testHelpers.js';
+
+test.after(() => destroyStubGame());
 
 test('level 1 obstacles have tree dimensions', () => {
   const game = createStubGame({ search: '?level=1' });

--- a/level2.test.js
+++ b/level2.test.js
@@ -1,11 +1,13 @@
 import test from 'node:test';
 import assert from 'node:assert';
-import { createStubGame } from './testHelpers.js';
+import { createStubGame, destroyStubGame } from './testHelpers.js';
 import { Level2 } from './src/levels/level2.js';
 import { Level3 } from './src/levels/level3.js';
 import { SHIELD_COOLDOWN } from './src/config.js';
 
 const FRAME = 1 / 60;
+
+test.after(() => destroyStubGame());
 
 test('level 2 maps space to shield only', () => {
   const game = createStubGame({ search: '?level=2', skipLevelUpdate: true });

--- a/level3-enemies.test.js
+++ b/level3-enemies.test.js
@@ -1,7 +1,7 @@
 import test, { describe } from 'node:test';
 import assert from 'node:assert';
 import { withLevel3, FRAME } from './level3TestHelpers.js';
-import { createStubGame } from './testHelpers.js';
+import { createStubGame, destroyStubGame } from './testHelpers.js';
 import { Goomba } from './src/entities/goomba.js';
 import { ShadowCrow } from './src/entities/shadowCrow.js';
 import { RhombusSprite } from './src/entities/rhombusSprite.js';
@@ -9,6 +9,8 @@ import { ThornGuard } from './src/entities/thornGuard.js';
 import { PortalGuardian } from './src/entities/portalGuardian.js';
 
 // Enemy-related tests for Level 3
+
+test.after(() => destroyStubGame());
 
 describe('Level 3 enemies', () => {
   describe('spawning', () => {

--- a/level3-mechanics.test.js
+++ b/level3-mechanics.test.js
@@ -1,13 +1,15 @@
 import test, { describe } from 'node:test';
 import assert from 'node:assert';
 import { withLevel3, FRAME } from './level3TestHelpers.js';
-import { createStubGame } from './testHelpers.js';
+import { createStubGame, destroyStubGame } from './testHelpers.js';
 import { LEVEL3_MAP } from './src/levels/level3.js';
 import { JUMP_VELOCITY, SHIELD_GRACE } from './src/config.js';
 import { Goomba } from './src/entities/goomba.js';
 import { Obstacle } from './src/obstacle.js';
 
 // Mechanics and general level features
+
+test.after(() => destroyStubGame());
 
 describe('Level 3 mechanics', () => {
   describe('level basics', () => {

--- a/level3-powerups.test.js
+++ b/level3-powerups.test.js
@@ -1,7 +1,7 @@
 import test, { describe } from 'node:test';
 import assert from 'node:assert';
 import { withLevel3, FRAME } from './level3TestHelpers.js';
-import { createStubGame } from './testHelpers.js';
+import { createStubGame, destroyStubGame } from './testHelpers.js';
 import {
   AURA_SHIELD_DURATION,
   WIND_HOOVES_DURATION,
@@ -10,6 +10,8 @@ import {
 } from './src/config.js';
 
 // Power-up related tests for Level 3
+
+test.after(() => destroyStubGame());
 
 describe('Level 3 power-ups', () => {
   describe('availability', () => {

--- a/obstacleSpawn.test.js
+++ b/obstacleSpawn.test.js
@@ -1,8 +1,10 @@
 import test from 'node:test';
 import assert from 'node:assert';
-import { createStubGame } from './testHelpers.js';
+import { createStubGame, destroyStubGame } from './testHelpers.js';
 
 const FRAME = 1 / 60;
+
+test.after(() => destroyStubGame());
 
 test('spawns a new obstacle after interval', () => {
   const game = createStubGame();

--- a/resizeCanvas.test.js
+++ b/resizeCanvas.test.js
@@ -1,9 +1,11 @@
 import test from 'node:test';
 import assert from 'node:assert';
-import { createStubGame } from './testHelpers.js';
+import { createStubGame, destroyStubGame } from './testHelpers.js';
 
 // If the canvas is not yet visible, getBoundingClientRect can return zeros.
 // resizeCanvas should fall back to window dimensions so the scale isn't 0.
+test.after(() => destroyStubGame());
+
 test('resizeCanvas falls back to window size when bounding rect is zero', () => {
   const game = createStubGame();
   window.innerWidth = 1000;

--- a/testHelpers.js
+++ b/testHelpers.js
@@ -1,5 +1,12 @@
 import { Game } from './src/game.js';
 
+const originalWindow = global.window;
+const originalDocument = global.document;
+const originalLocalStorage = global.localStorage;
+const hadWindow = Object.prototype.hasOwnProperty.call(global, 'window');
+const hadDocument = Object.prototype.hasOwnProperty.call(global, 'document');
+const hadLocalStorage = Object.prototype.hasOwnProperty.call(global, 'localStorage');
+
 const localStorageStub = (() => {
   let store = {};
   return {
@@ -17,7 +24,6 @@ const localStorageStub = (() => {
     },
   };
 })();
-global.localStorage = localStorageStub;
 
 export function createStubGame({
   rng,
@@ -27,6 +33,7 @@ export function createStubGame({
   search = '',
   skipLevelUpdate = false,
 } = {}) {
+  global.localStorage = localStorageStub;
   const noop = () => {};
   const ctx = {
     clearRect: noop,
@@ -104,4 +111,14 @@ export function createStubGame({
     game.level.update = noop;
   }
   return game;
+}
+
+export function destroyStubGame() {
+  if (hadWindow) global.window = originalWindow;
+  else delete global.window;
+  if (hadDocument) global.document = originalDocument;
+  else delete global.document;
+  if (hadLocalStorage) global.localStorage = originalLocalStorage;
+  else delete global.localStorage;
+  localStorageStub.clear();
 }


### PR DESCRIPTION
## Summary
- add `destroyStubGame` to reset window, document and storage between suites
- register `test.after` hook in each test file to invoke cleanup

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b04ae1f67c832c9b974203f4c97cf2