### PR TITLE
feat: add Level 3 camera dead zone

### DIFF
--- a/level3-mechanics.test.js
+++ b/level3-mechanics.test.js
@@ -28,7 +28,7 @@ describe('Level 3 mechanics', () => {
         game.update(1);
         assert.strictEqual(level.distance, 0);
         player.moveRight();
-        game.update(1);
+        for (let i = 0; i < 120; i++) game.update(FRAME);
         assert.ok(level.distance > 0);
       });
     });
@@ -37,6 +37,30 @@ describe('Level 3 mechanics', () => {
       withLevel3({ skipLevelUpdate: true }, ({ game, player }) => {
         const ratio = player.x / game.worldWidth;
         assert.ok(ratio >= 0.45 && ratio <= 0.55);
+      });
+    });
+
+    test('camera scrolls only outside dead zone', () => {
+      withLevel3({}, ({ game, level, player }) => {
+        player.vx = 0;
+        player.x = game.worldWidth / 2;
+        game.update(FRAME);
+        player.x =
+          game.worldWidth / 2 +
+          (game.worldWidth * level.deadZoneWidthPct) / 2 -
+          0.1;
+        game.update(FRAME);
+        assert.strictEqual(level.scrollX, 0);
+        player.x =
+          game.worldWidth / 2 +
+          (game.worldWidth * level.deadZoneWidthPct) / 2 +
+          1;
+        game.update(FRAME);
+        for (let i = 0; i < 5; i++) game.update(FRAME);
+        assert.ok(level.scrollX > 0);
+        const maxX =
+          game.worldWidth / 2 + (game.worldWidth * level.deadZoneWidthPct) / 2 + 1;
+        assert.ok(player.x <= maxX);
       });
     });
 

--- a/src/game.js
+++ b/src/game.js
@@ -223,12 +223,24 @@ export class Game {
     // Always apply gravity after a loss so the death animation completes.
     // Only skip gravity when the player has won, so they remain in place.
     const wasJumping = this.player.jumping;
-    const prevX = this.player.x;
     this.player.update(this.win ? 0 : this.gravity, this.groundY, delta);
-    const deltaX = this.player.x - prevX;
     if (this.level.disableAutoScroll) {
-      this.player.x = prevX;
-      this.level.update(delta, deltaX);
+      const level = this.level;
+      const worldX = level.scrollX + this.player.x;
+      const dzWidth = this.worldWidth * level.deadZoneWidthPct;
+      const dzLeft = this.worldWidth / 2 - dzWidth / 2;
+      const dzRight = dzLeft + dzWidth;
+      let targetScroll = level.scrollX;
+      if (this.player.x < dzLeft) targetScroll = worldX - dzLeft;
+      else if (this.player.x > dzRight) targetScroll = worldX - dzRight;
+      const maxScroll = level.levelLength;
+      if (targetScroll < 0) targetScroll = 0;
+      if (targetScroll > maxScroll) targetScroll = maxScroll;
+      const prevScroll = level.scrollX;
+      level.scrollX += (targetScroll - level.scrollX) * level.cameraLerp;
+      const move = level.scrollX - prevScroll;
+      this.player.x = worldX - level.scrollX;
+      level.update(delta, move);
     } else {
       this.level.update(delta);
     }

--- a/src/levels/level3.js
+++ b/src/levels/level3.js
@@ -119,6 +119,11 @@ export class Level3 extends BaseLevel {
     this.tileSize = 1; // world units per tile
     this.distance = 0;
     this.levelLength = this.map[0].length * this.tileSize;
+    this.scrollX = 0;
+    const params = this.game.params;
+    this.deadZoneWidthPct = parseFloat(params.get('deadZoneWidthPct')) || 0.5;
+    this.deadZoneHeightPct = parseFloat(params.get('deadZoneHeightPct')) || 0.5;
+    this.cameraLerp = parseFloat(params.get('cameraLerp')) || 0.1;
     this.platforms = [];
     this.pipes = [];
     this.blocks = [];
@@ -251,6 +256,8 @@ export class Level3 extends BaseLevel {
 
   respawnPlayer() {
     const player = this.game.player;
+    this.scrollX = 0;
+    this.distance = 0;
     const { x, y } = this.respawnPoint || {
       x: player.x,
       y: this.game.groundY - player.height / 2,
@@ -341,7 +348,7 @@ export class Level3 extends BaseLevel {
     ];
   }
 
-  update(delta, move = this.game.player.vx * delta) {
+  update(delta, move = 0) {
     if (this.respawning) {
       this.respawnTimer += delta;
       if (this.respawnTimer >= 1) {


### PR DESCRIPTION
## Summary
- add camera dead-zone parameters for Level 3 and track scroll offset
- follow player outside dead-zone with smooth lerp and clamp
- add regression test for camera behavior

## Testing
- `npm test`
- `npm run uat`


------
https://chatgpt.com/codex/tasks/task_e_68b080b9fb04832cb15cf3f93cab10f1