### PR TITLE
Add mobile controls for level 3

### DIFF
--- a/index.html
+++ b/index.html
@@ -18,6 +18,11 @@
     </div>
     <canvas id="game" class="hidden"></canvas>
   </div>
+  <div id="mobile-controls" class="hidden">
+    <button id="left-control">◀</button>
+    <button id="jump-control">▲</button>
+    <button id="right-control">▶</button>
+  </div>
   <div id="overlay" class="overlay hidden">
     <div id="overlay-content"></div>
     <button id="overlay-button">Continua</button>

--- a/main.js
+++ b/main.js
@@ -9,8 +9,27 @@ window.addEventListener('DOMContentLoaded', () => {
   const instructionsButton = document.getElementById('instructions-button');
   const creditsButton = document.getElementById('credits-button');
   const overlay = new Overlay();
+  const mobileControls = document.getElementById('mobile-controls');
+  const leftBtn = document.getElementById('left-control');
+  const rightBtn = document.getElementById('right-control');
+  const jumpBtn = document.getElementById('jump-control');
 
   let game;
+
+  const sendInput = (code, type) => {
+    if (!game) return;
+    game.handleInput(code, type);
+  };
+
+  const stop = e => e.stopPropagation();
+
+  leftBtn.addEventListener('pointerdown', e => { stop(e); sendInput('ArrowLeft', 'down'); });
+  leftBtn.addEventListener('pointerup', e => { stop(e); sendInput('ArrowLeft', 'up'); });
+  rightBtn.addEventListener('pointerdown', e => { stop(e); sendInput('ArrowRight', 'down'); });
+  rightBtn.addEventListener('pointerup', e => { stop(e); sendInput('ArrowRight', 'up'); });
+  jumpBtn.addEventListener('pointerdown', e => { stop(e); sendInput('Space', 'down'); });
+  jumpBtn.addEventListener('pointerup', e => { stop(e); sendInput('Space', 'up'); });
+
   playButton.addEventListener('click', () => {
     menu.classList.add('hidden');
     canvas.classList.remove('hidden');
@@ -20,6 +39,7 @@ window.addEventListener('DOMContentLoaded', () => {
       game = new Game(canvas);
     }
     game.resizeCanvas();
+    mobileControls.classList.toggle('hidden', game.levelNumber !== 3);
   });
 
   instructionsButton.addEventListener('click', () => {

--- a/src/texts.js
+++ b/src/texts.js
@@ -1,7 +1,7 @@
 export const INSTRUCTIONS_TEXT = {
   1: 'Salta gli ostacoli premendo la barra spaziatrice o toccando lo schermo.',
   2: 'Attiva lo scudo per rompere i muri del Cavaliere Nero premendo la barra spaziatrice o toccando lo schermo.',
-  3: 'Affronta il sentiero incantato di Unicornolandia evitando i minicactus con la barra spaziatrice o un tocco sullo schermo.'
+  3: 'Affronta il sentiero incantato di Unicornolandia: usa le frecce o i pulsanti sullo schermo per muoverti e salta con la barra spaziatrice o il pulsante centrale.'
 };
 
 export const STORY_TEXT = {

--- a/style.css
+++ b/style.css
@@ -79,4 +79,26 @@ canvas {
   color: #f5e6c8;
   font-family: "Bellefair", serif;
 }
+#mobile-controls {
+  position: fixed;
+  bottom: 20px;
+  left: 50%;
+  transform: translateX(-50%);
+  display: flex;
+  gap: 20px;
+}
+
+#mobile-controls button {
+  width: 60px;
+  height: 60px;
+  border-radius: 50%;
+  font-size: 1.5em;
+  background: linear-gradient(#8b5a2b, #5e3f1c);
+  border: 2px solid #d4af37;
+  color: #f5e6c8;
+}
+
+@media (hover: hover) and (pointer: fine) {
+  #mobile-controls { display: none; }
+}
 .hidden { display: none !important; }


### PR DESCRIPTION
## Summary
- Add on-screen buttons and styling for mobile play
- Wire buttons to game input and show only in level 3
- Update level 3 instructions with mobile control hints

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b16b57e888832ca18a65ae128f81c1