### PR TITLE
Show mobile controls when entering level 3

### DIFF
--- a/main.js
+++ b/main.js
@@ -37,9 +37,14 @@ window.addEventListener('DOMContentLoaded', () => {
       game.reset();
     } else {
       game = new Game(canvas);
+      game.onLevelChange = level => {
+        mobileControls.classList.toggle('hidden', level !== 3);
+      };
     }
     game.resizeCanvas();
-    mobileControls.classList.toggle('hidden', game.levelNumber !== 3);
+    if (typeof game.onLevelChange === 'function') {
+      game.onLevelChange(game.levelNumber);
+    }
   });
 
   instructionsButton.addEventListener('click', () => {

--- a/src/game.js
+++ b/src/game.js
@@ -22,6 +22,7 @@ export class Game {
     this.canvas = canvas;
     this.ctx = canvas.getContext('2d');
     this.overlay = new Overlay();
+    this.onLevelChange = null;
     this.random = randomFn;
 
     this.speed = GAME_SPEED; // world units per second
@@ -261,6 +262,9 @@ export class Game {
 
     if (this.levelNumber === 1 && this.score >= LEVEL_UP_SCORE) {
       this.levelNumber = 2;
+      if (typeof this.onLevelChange === 'function') {
+        this.onLevelChange(this.levelNumber);
+      }
       this.initializeLevel();
       this.gamePaused = true;
       this.showOverlay(STORY_TEXT[1], () => {
@@ -270,6 +274,9 @@ export class Game {
 
     if (this.levelNumber === 2 && this.gameOver && this.win) {
       this.levelNumber = 3;
+      if (typeof this.onLevelChange === 'function') {
+        this.onLevelChange(this.levelNumber);
+      }
       this.initializeLevel();
       this.gamePaused = true;
       this.gameOver = false;


### PR DESCRIPTION
## Summary
- Expose `onLevelChange` callback in Game for level transitions
- Toggle mobile controls visibility based on level via callback

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b170eb8734832c9421cf87bbf5c3ce