### PR TITLE
Allow landing overlap tolerance

### DIFF
--- a/collision.js
+++ b/collision.js
@@ -17,7 +17,9 @@ export function isColliding(a, b) {
   );
 }
 
-export function isLandingOn(a, b) {
+export const LANDING_EPSILON = 0.001;
+
+export function isLandingOn(a, b, epsilon = LANDING_EPSILON) {
   if (!isColliding(a, b)) return false;
   const aBottom = a.y + a.height / 2;
   const bTop = b.y - b.height / 2;
@@ -27,5 +29,5 @@ export function isLandingOn(a, b) {
   const bRight = b.x + b.width / 2;
   const bLeft = b.x - b.width / 2;
   const horizontalOverlap = Math.min(aRight, bRight) - Math.max(aLeft, bLeft);
-  return verticalOverlap < horizontalOverlap && a.vy > 0;
+  return verticalOverlap <= horizontalOverlap + epsilon && a.vy > 0;
 }

--- a/collision.test.js
+++ b/collision.test.js
@@ -1,6 +1,6 @@
 import test from 'node:test';
 import assert from 'node:assert';
-import { isColliding } from './collision.js';
+import { isColliding, isLandingOn } from './collision.js';
 
 const groundY = 1.5;
 
@@ -51,4 +51,25 @@ test('extended width collider detects earlier collision', () => {
   const obstacle = createEntity(1.45, groundY, 0.32, 0.64);
   assert.strictEqual(isColliding(unicorn, obstacle), false);
   assert.strictEqual(isColliding(shielded, obstacle), true);
+});
+
+test('landing detected when overlaps are equal', () => {
+  const platform = createEntity(0, 1, 1, 1);
+  const falling = createEntity(0.75, 0.25, 0.25, 1);
+  falling.vy = 1;
+  assert.strictEqual(isLandingOn(falling, platform, 0), true);
+});
+
+test('allows small landing tolerance with epsilon', () => {
+  const platform = createEntity(0, 1, 1, 1);
+  const falling = createEntity(0.81, 0.2, 0.19, 1);
+  falling.vy = 1;
+  assert.strictEqual(isLandingOn(falling, platform, 0.02), true);
+});
+
+test('no landing when overlap exceeds epsilon', () => {
+  const platform = createEntity(0, 1, 1, 1);
+  const falling = createEntity(0.81, 0.2, 0.19, 1);
+  falling.vy = 1;
+  assert.strictEqual(isLandingOn(falling, platform, 0.005), false);
 });


### PR DESCRIPTION
## Summary
- add `LANDING_EPSILON` constant and parameterize `isLandingOn`
- permit slight vertical overlap when landing
- test landing detection with and without epsilon tolerance

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b5fdd1b448832c87267137b43bcec0