### PR TITLE
Add workflow to request Copilot review on new PRs

### DIFF
--- a/.github/workflows/request-copilot-review.yml
+++ b/.github/workflows/request-copilot-review.yml
@@ -1,0 +1,42 @@
+name: Request GitHub Copilot Review
+
+on:
+  pull_request:
+    types:
+      - opened
+      - ready_for_review
+
+permissions:
+  pull-requests: write
+
+jobs:
+  request-review:
+    if: github.event.pull_request.draft == false
+    runs-on: ubuntu-latest
+    steps:
+      - name: Request review from GitHub Copilot
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+            const pull_number = context.payload.pull_request.number;
+
+            try {
+              await github.rest.pulls.requestReviewers({
+                owner,
+                repo,
+                pull_number,
+                reviewers: ["github-copilot"],
+              });
+              core.info("Requested review from GitHub Copilot.");
+            } catch (error) {
+              if (error.status === 422) {
+                core.info("Review request already exists or reviewer unavailable.");
+              } else if (error.status === 404) {
+                core.warning("GitHub Copilot reviewer is not available for this repository.");
+              } else {
+                throw error;
+              }
+            }


### PR DESCRIPTION
## Summary
- add a GitHub Actions workflow that requests a review from GitHub Copilot when a pull request is opened or marked ready for review

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d6b120fa48832c86d9091e159f90f2